### PR TITLE
Implement temperature and dynamic engine parameter sending

### DIFF
--- a/conversions/engineParameters.js
+++ b/conversions/engineParameters.js
@@ -1,0 +1,124 @@
+const debug = require("debug")("signalk:signalk-to-nmea2000");
+const _ = require('lodash')
+
+const DEFAULT_TIMEOUT = 10000  // ms
+
+module.exports = (app, plugin) => {
+
+  // discrete status fields are not yet implemented
+  const engParKeys = [
+      'oilPressure',
+      'oilTemperature',
+      'temperature',
+      'alternatorVoltage',
+      'fuel.rate',
+      'runTime',
+      'coolantPressure',
+      'fuel.pressure',
+      'engineLoad',
+      'engineTorque'
+  ]
+
+  return [{
+    title: 'Temperature, exhaust (130312)',
+    optionKey: 'EXHAUST_TEMPERATURE',
+    context: 'vessels.self',
+    properties: {
+      engines: {
+        title: 'Engine Mapping',
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            signalkId: {
+              title: 'Signal K engine id',
+              type: 'string'
+            },
+            tempInstanceId: {
+              title: 'NMEA2000 Temperature Instance Id',
+              type: 'number'
+            }
+          }
+        }
+      }
+    },
+
+    conversions: (options) => {
+      if ( !_.get(options, 'EXHAUST_TEMPERATURE.engines') ) {
+        return null
+      }
+      return options.EXHAUST_TEMPERATURE.engines.map(engine => {
+        return {
+          keys: [
+            `propulsion.${engine.signalkId}.exhaustTemperature`
+          ],
+          callback: (temperature) => {
+            return [{
+              pgn: 130312,
+              SID: 0xff,
+              "Temperature Instance": engine.tempInstanceId,
+              "Temperature Source": 14,
+              "Actual Temperature": temperature,
+            }]
+          }
+        }
+      })
+    }
+  },
+  {
+    //pgn: 127489,
+    title: 'Engine Parameters, Dynamic (127489)',
+    optionKey: 'ENGINE_PARAMETERS',
+    context: 'vessels.self',
+    properties: {
+      engines: {
+        title: 'Engine Mapping',
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            signalkId: {
+              title: 'Signal K engine id',
+              type: 'string'
+            },
+            instanceId: {
+              title: 'NMEA2000 Engine Instance Id',
+              type: 'number'
+            }
+          }
+        }
+      }
+    },
+
+    conversions: (options) => {
+      if ( !_.get(options, 'ENGINE_PARAMETERS.engines') ) {
+        return null
+      }
+      return options.ENGINE_PARAMETERS.engines.map(engine => {
+        return {
+          keys: engParKeys.map(key => `propulsion.${engine.signalkId}.${key}`),
+          timeouts: engParKeys.map(key => DEFAULT_TIMEOUT),
+          callback: (oilPres, oilTemp, temp, altVolt, fuelRate, runTime, coolPres, fuelPres, engLoad, engTorque) => {
+            return [{
+                pgn: 127489,
+                "Engine Instance": engine.instanceId,
+                "Oil Pressure": _.isUndefined(oilPres) ? undefined : oilPres / 100,
+                "Oil Temperature": oilTemp,
+                "Temperature": temp,
+                "Alternator Potential": altVolt,
+                "Fuel Rate": _.isUndefined(fuelRate) ? undefined : fuelRate / 3600 * 1000,
+                "Total Engine Hours": _.isUndefined(runTime) ? undefined : runTime / 3600,
+                "Coolant Pressure": _.isUndefined(coolPres) ? undefined : coolPres / 100,
+                "Fuel Pressure": _.isUndefined(fuelPres) ? undefined : fuelPres / 100,
+                "Reserved": 0,
+                "Discrete Status 1": undefined,
+                "Discrete Status 2": undefined,
+                "Percent Engine Load": _.isUndefined(engLoad) ? undefined : engLoad * 100,
+                "Percent Engine Torque": _.isUndefined(engTorque) ? undefined : engTorque * 100
+            }]
+          }
+        }
+      })
+    }
+  }]
+}

--- a/conversions/temperature.js
+++ b/conversions/temperature.js
@@ -1,0 +1,58 @@
+
+let tempMessage = (temp, inst, src) => {
+  return [{
+    pgn: 130312,
+    SID: 0xff,
+    "Temperature Instance": inst,
+    "Temperature Source": src,
+    "Actual Temperature": temp,
+  }]
+}
+
+module.exports = (app, plugin) => {
+  return [{
+    pgn: 130312,
+    title: 'Temperature (130312)',
+    optionKey: 'TEMPERATURE',
+    keys: [
+      "environment.outside.temperature"
+    ],
+    callback: (temperature) => {
+      return tempMessage(temperature, 101, 1)
+    },
+  },
+  {
+    pgn: 130312,
+    title: 'Temperature (130312)',
+    optionKey: 'TEMPERATURE',
+    keys: [
+      "environment.inside.temperature"
+    ],
+    callback: (temperature) => {
+      return tempMessage(temperature, 102, 2)
+    }
+  },
+  {
+    pgn: 130312,
+    title: 'Temperature (130312)',
+    optionKey: 'TEMPERATURE',
+    keys: [
+      "environment.inside.engineRoom.temperature"
+    ],
+    callback: (temperature) => {
+      return tempMessage(temperature, 103, 3)
+    }
+  },
+  {
+    pgn: 130312,
+    title: 'Temperature (130312)',
+    optionKey: 'TEMPERATURE',
+    keys: [
+      "environment.inside.refridgerator.temperature"
+    ],
+    callback: (temperature) => {
+      return tempMessage(temperature, 107, 7)
+    }
+  }
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function(app) {
     Source type can be:
 
       onDelta - You will get all deltas via app.signalk.on('delta', ...). Please do no use this unless absolutely necessary.
-      
+
       onValueChange - The conversion should specify a variable called 'keys' which is an array of the Signal K paths that the convesion needs
 
       timer - The conversions callback will get called per the givien 'interval' variable
@@ -56,9 +56,9 @@ module.exports = function(app) {
     "If there is SignalK data for the conversion generate the following NMEA2000 pgns from Signal K data:",
     properties: {}
   };
-  
+
   updateSchema()
-  
+
   function updateSchema() {
     conversions.forEach(conversion => {
       var obj =  {
@@ -72,9 +72,9 @@ module.exports = function(app) {
           }
         }
       }
-      
+
       schema.properties[conversion.optionKey] = obj
-      
+
       if ( conversion.properties ) {
         var props = typeof conversion.properties === 'function' ? conversion.properties() : conversion.properties
         _.extend(obj.properties, props)
@@ -86,7 +86,7 @@ module.exports = function(app) {
     updateSchema()
     return schema
   }
-  
+
   plugin.start = function(options) {
     debug("start");
 
@@ -193,7 +193,7 @@ module.exports = function(app) {
         })
     );
   }
-  
+
   function mapOnDelta(conversion) {
     app.signalk.on('delta', (delta) => {
       try {
@@ -214,7 +214,7 @@ module.exports = function(app) {
   {
     console.log("error: " + err)
   }
-  
+
   function mapSubscription(mapping, options) {
     var subscription = {
       "context": mapping.context,


### PR DESCRIPTION
Implement temperature (PGN 130312) and dynamic engine parameters (PGN 127489).

Warts:

- Temperature messages currently hard-code the temperature instance id. It wasn't immediately obvious to me how to make them configurable in a clean fashion.
- Discrete dynamic engine parameters aren't implemented yet.