### PR TITLE
[WIP] convert OpenCPN route information to N2K

### DIFF
--- a/conversions/autopilot.js
+++ b/conversions/autopilot.js
@@ -18,25 +18,30 @@ module.exports = (app, plugin) => {
     optionKey: 'AUTOPILOTv2',
     keys: [
       'navigation.headingMagnetic',
+      'navigation.headingTrue',
       'navigation.magneticVariation',
       'navigation.courseRhumbline.crossTrackError',
-      'navigation.courseRhumbline'
+      'navigation.courseRhumbline.nextPoint'
     ],
-    callback: (heading, variation, XTE, courseRhumbline) => {
+    callback: (headingMagnetic, headingTrue, variation, XTE, nextPoint) => {
       const now = DateTime.local()
       const days = Math.floor(now.toMillis() / 86400000) // Days since January 1, 1970
 
       console.log('[navigation.courseRhumbline]', JSON.stringify({
-        heading, variation, XTE, courseRhumbline
+        headingMagnetic,
+        headingTrue,
+        variation,
+        XTE,
+        nextPoint
       }, null, 2))
-      
+
       return [
         /*
         {
           pgn: 129284,
           SID: 87,
           'Distance to Waypoint': -1,
-          'Course/Bearing reference': 1, // magnetic
+          'Course/Bearing reference': headingMagnetic ? 1 : 0, // magnetic
           'Perpendicular Crossed': 0, // no
           'Arrival Circle Entered': 0, // no
           'Calculation Type': 1, // rhumbline
@@ -68,7 +73,7 @@ module.exports = (app, plugin) => {
           'Radius of Turn Order': -1,
           'Rate of Turn Order': -1,
           'Off-Track Limit': -1,
-          'Vessel Heading': heading
+          'Vessel Heading': headingMagnetic || headingTrue
         },
         // */
         {

--- a/conversions/autopilot.js
+++ b/conversions/autopilot.js
@@ -1,4 +1,6 @@
-const { DateTime } = require('luxon')
+// const { DateTime } = require('luxon')
+const debug = require('debug')('signalk-to-nmea2000/conversions/autopilot')
+
 
 /**
  * APB: 127237 (Heading/Track control) X, 129283 (Cross Track Error) X, 129284 (Navigation Data) X
@@ -37,12 +39,12 @@ module.exports = (app, plugin) => {
           'Distance to Waypoint': distance,
           'Course/Bearing reference': 0, // true
           'Calculation Type': 1, // rhumbline
-          'ETA Time': -1, // seconds since midnight
-          'ETA Date': -1, // days since epoch
+          // 'ETA Time': -1, // seconds since midnight
+          // 'ETA Date': -1, // days since epoch
           // 'Bearing, Origin to Destination Waypoint': -1,
           'Bearing, Position to Destination Waypoint': bearingTrue,
           // 'Origin Waypoint Number': -1,
-          'Destination Waypoint Number': -1,
+          // 'Destination Waypoint Number': -1,
           'Destination Latitude': nextPointPosition.latitude,
           'Destination Longitude': nextPointPosition.longitude
         },
@@ -56,7 +58,6 @@ module.exports = (app, plugin) => {
           pgn: 129283, // XTE
           SID: 87,
           'XTE mode': 2, // Estimated
-          'Navigation Terminated': 0, // No
           XTE
         },
         (!magneticVariation || !magneticVariationAgeOfService) ? null : {
@@ -67,7 +68,7 @@ module.exports = (app, plugin) => {
           'Age of service': Math.floor(magneticVariationAgeOfService / 86400000) // Days since epoch
         }
       ].filter(pgn => (pgn !== null)).map(pgn => {
-        console.log(`Sending PGN ${pgn.pgn}: ${JSON.stringify(pgn, null, 2)}`)
+        debug(`Sending PGN ${pgn.pgn}: ${JSON.stringify(pgn, null, 2)}`)
         return pgn
       })
     }

--- a/conversions/autopilot.js
+++ b/conversions/autopilot.js
@@ -21,9 +21,12 @@ module.exports = (app, plugin) => {
       'navigation.headingTrue',
       'navigation.magneticVariation',
       'navigation.courseRhumbline.crossTrackError',
-      'navigation.courseRhumbline.nextPoint'
+      'navigation.courseRhumbline.nextPoint',
+      'navigation.courseRhumbline.nextPoint.bearingTrue',
+      'navigation.courseRhumbline.nextPoint.velocityMadeGood',
+      'navigation.courseRhumbline.nextPoint.distance'
     ],
-    callback: (headingMagnetic, headingTrue, variation, XTE, nextPoint) => {
+    callback: (headingMagnetic, headingTrue, variation, XTE, nextPointPosition, bearingTrue, velocityMadeGood, distance) => {
       const now = DateTime.local()
       const days = Math.floor(now.toMillis() / 86400000) // Days since January 1, 1970
 
@@ -32,7 +35,10 @@ module.exports = (app, plugin) => {
         headingTrue,
         variation,
         XTE,
-        nextPoint
+        nextPointPosition,
+        bearingTrue,
+        velocityMadeGood,
+        distance
       }, null, 2))
 
       return [

--- a/conversions/autopilot.js
+++ b/conversions/autopilot.js
@@ -3,7 +3,7 @@ const { DateTime } = require('luxon')
 /**
  * APB: 127237 (Heading/Track control) X, 129283 (Cross Track Error) X, 129284 (Navigation Data) X
  * RMC: 127258 (Magnetic Variation) X
- * 
+ *
  * One also should enable conversions for (if not present on network):
  * - systemTime
  * - cogSOG
@@ -13,6 +13,7 @@ const { DateTime } = require('luxon')
 
 module.exports = (app, plugin) => {
   return {
+    pgns: [ 127237, 129283, 129284, 127258 ],
     title: 'Autopilot Routing Data',
     optionKey: 'AUTOPILOTv2',
     keys: [
@@ -25,7 +26,10 @@ module.exports = (app, plugin) => {
       const now = DateTime.local()
       const days = Math.floor(now.toMillis() / 86400000) // Days since January 1, 1970
 
-      console.log('[navigation.courseRhumbline]', JSON.stringify(courseRhumbline, null, 2))
+      console.log('[navigation.courseRhumbline]', JSON.stringify({
+        heading, variation, XTE, courseRhumbline
+      }, null, 2))
+      
       return [
         /*
         {
@@ -79,7 +83,7 @@ module.exports = (app, plugin) => {
           SID: 87,
           Source: 1, // Automatic Chart
           Variation: variation, // Variation with resolution 0.0001 in rad,
-          'Age of service': days, // Days since epoch
+          'Age of service': days // Days since epoch
         }
       ]
     }

--- a/conversions/autopilot.js
+++ b/conversions/autopilot.js
@@ -14,7 +14,7 @@ const { DateTime } = require('luxon')
 module.exports = (app, plugin) => {
   return {
     title: 'Autopilot Routing Data',
-    optionKey: 'AUTOPILOTv1',
+    optionKey: 'AUTOPILOTv2',
     keys: [
       'navigation.headingMagnetic',
       'navigation.magneticVariation',

--- a/conversions/autopilot.js
+++ b/conversions/autopilot.js
@@ -1,0 +1,87 @@
+const { DateTime } = require('luxon')
+
+/**
+ * APB: 127237 (Heading/Track control) X, 129283 (Cross Track Error) X, 129284 (Navigation Data) X
+ * RMC: 127258 (Magnetic Variation) X
+ * 
+ * One also should enable conversions for (if not present on network):
+ * - systemTime
+ * - cogSOG
+ * - heading
+ * - gps
+ */
+
+module.exports = (app, plugin) => {
+  return {
+    title: 'Autopilot Routing Data',
+    optionKey: 'AUTOPILOTv1',
+    keys: [
+      'navigation.headingMagnetic',
+      'navigation.magneticVariation',
+      'navigation.courseRhumbline.crossTrackError',
+      'navigation.courseRhumbline'
+    ],
+    callback: (heading, variation, XTE, courseRhumbline) => {
+      const now = DateTime.local()
+      const days = Math.floor(now.toMillis() / 86400000) // Days since January 1, 1970
+
+      console.log('[navigation.courseRhumbline]', JSON.stringify(courseRhumbline, null, 2))
+      return [
+        /*
+        {
+          pgn: 129284,
+          SID: 87,
+          'Distance to Waypoint': -1,
+          'Course/Bearing reference': 1, // magnetic
+          'Perpendicular Crossed': 0, // no
+          'Arrival Circle Entered': 0, // no
+          'Calculation Type': 1, // rhumbline
+          'ETA Time': -1, // seconds since midnight
+          'ETA Date': -1, // days since epoch
+          'Bearing, Origin to Destination Waypoint': -1,
+          'Bearing, Position to Destination Waypoint': -1,
+          'Origin Waypoint Number': -1,
+          'Destination Waypoint Number': -1,
+          'Destination Latitude': -1,
+          'Destination Longitude': -1,
+          'Waypoint Closing Velocity': -1
+        },
+        {
+          pgn: 127237,
+          'Rudder Limit Exceeded': -1,
+          'Off-Heading Limit Exceeded': -1,
+          'Off-Track Limit Exceeded': -1,
+          Override: -1,
+          'Steering Mode': -1,
+          'Turn Mode': -1,
+          'Heading Reference': -1,
+          'Commanded Rudder Direction': -1,
+          'Commanded Rudder Angle': -1,
+          'Heading-To-Steer (Course)': -1,
+          'Track': -1,
+          'Rudder Limit': -1,
+          'Off-Heading Limit': -1,
+          'Radius of Turn Order': -1,
+          'Rate of Turn Order': -1,
+          'Off-Track Limit': -1,
+          'Vessel Heading': heading
+        },
+        // */
+        {
+          pgn: 129283, // XTE
+          SID: 87,
+          'XTE mode': 2, // Estimated
+          'Navigation Terminated': 0, // No
+          XTE
+        },
+        {
+          pgn: 127258, // Magnetic variation
+          SID: 87,
+          Source: 1, // Automatic Chart
+          Variation: variation, // Variation with resolution 0.0001 in rad,
+          'Age of service': days, // Days since epoch
+        }
+      ]
+    }
+  }
+}

--- a/conversions/systemTime.js
+++ b/conversions/systemTime.js
@@ -1,23 +1,33 @@
+const { DateTime } = require('luxon')
 
 module.exports = (app, plugin) => {
   return {
-    title: 'System Time (126992)',
+    title: 'System Time (126992 & 129033)',
     sourceType: 'timer',
     interval: 1000,
     optionKey: 'SYSTEM_TIMEv2',
     callback: (app) => {
-      var dateObj = new Date();
-      var date = Math.trunc(dateObj.getTime() / 86400 / 1000);
-      var time =
-          dateObj.getUTCHours() * (60 * 60) +
-          dateObj.getUTCMinutes() * 60 +
-          dateObj.getUTCSeconds();
+      const now = DateTime.local()
+      const startOfDay = now.startOf('day')
+
+      // For 126992
+      const date = Math.trunc(now.toMillis() / 86400 / 1000)
+      const time =
+          now.toUTC().hour * (60 * 60) +
+          now.toUTC().minute * 60 +
+          now.toUTC().second
       
       return [
         {
           pgn: 126992,
           Date: date,
           Time: time
+        },
+        {
+          pgn: 129033,
+          Date: Math.floor(now.toMillis() / 86400000), // Days since January 1, 1970
+          Time: Math.floor(now.diff(startOfDay).as('seconds')), // Seconds since midnight
+          'Local Offset': now.offset // Minutes (difference between UTC & local time?)
         }
       ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
       "dev": true,
       "requires": {
-        "any-observable": "0.3.0"
+        "any-observable": "^0.3.0"
       }
     },
     "@serialport/binding-abstract": {
@@ -25,7 +25,7 @@
       "integrity": "sha512-oRg0QRsXJFKHQbQjmo0regKLZ9JhjLmTqc47ocJgYM5UtU9Q1VFrVPh0B2lr2pfm/tr3aNvTLX1eiVAvXyZ/bg==",
       "dev": true,
       "requires": {
-        "debug": "4.1.1"
+        "debug": "^4.1.1"
       },
       "dependencies": {
         "debug": {
@@ -34,7 +34,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -51,8 +51,8 @@
       "integrity": "sha512-1kD1qI686pIIolGZ6TPjAtvy8c3XIUlE4OXRZf7ZHaZgGaOUHAUMLKZt4tNTxsfedRTFyiYyHoe5QAbx82R9pQ==",
       "dev": true,
       "requires": {
-        "@serialport/binding-abstract": "2.0.5",
-        "debug": "4.1.1"
+        "@serialport/binding-abstract": "^2.0.5",
+        "debug": "^4.1.1"
       },
       "dependencies": {
         "debug": {
@@ -61,7 +61,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -79,12 +79,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "@serialport/binding-abstract": "2.0.5",
-        "@serialport/parser-readline": "2.0.2",
-        "bindings": "1.5.0",
-        "debug": "4.1.1",
-        "nan": "2.14.0",
-        "prebuild-install": "5.3.0"
+        "@serialport/binding-abstract": "^2.0.5",
+        "@serialport/parser-readline": "^2.0.2",
+        "bindings": "^1.3.0",
+        "debug": "^4.1.1",
+        "nan": "^2.13.2",
+        "prebuild-install": "^5.2.1"
       },
       "dependencies": {
         "@serialport/parser-delimiter": {
@@ -101,7 +101,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "@serialport/parser-delimiter": "2.0.2"
+            "@serialport/parser-delimiter": "^2.0.2"
           }
         },
         "bindings": {
@@ -121,7 +121,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
@@ -165,7 +165,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "semver": "5.5.0"
+            "semver": "^5.4.1"
           }
         },
         "prebuild-install": {
@@ -175,22 +175,22 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "expand-template": "2.0.3",
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
             "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "napi-build-utils": "1.0.1",
-            "node-abi": "2.8.0",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "2.0.1",
-            "rc": "1.2.8",
-            "simple-get": "2.8.1",
-            "tar-fs": "1.16.0",
-            "tunnel-agent": "0.6.0",
-            "which-pm-runs": "1.0.0"
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "os-homedir": "^1.0.1",
+            "pump": "^2.0.1",
+            "rc": "^1.2.7",
+            "simple-get": "^2.7.0",
+            "tar-fs": "^1.13.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
           }
         },
         "pump": {
@@ -200,8 +200,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "rc": {
@@ -211,10 +211,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.6.0",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           }
         },
         "simple-get": {
@@ -224,9 +224,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "decompress-response": "3.3.0",
-            "once": "1.4.0",
-            "simple-concat": "1.0.0"
+            "decompress-response": "^3.3.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
           }
         }
       }
@@ -238,7 +238,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "@serialport/parser-cctalk": {
@@ -248,7 +248,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "@serialport/parser-delimiter": {
@@ -257,7 +257,7 @@
       "integrity": "sha512-srDzeNwGM/GjtqK/nFDRIDpcZ6XDgkakFMXBtNDSI+XP6fqO1ynEZok8ljKJxM2ay0CNG83C6/X2xIOHvWhFYQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "@serialport/parser-readline": {
@@ -267,8 +267,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "@serialport/parser-delimiter": "1.0.5",
-        "safe-buffer": "5.1.1"
+        "@serialport/parser-delimiter": "^1.0.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "@serialport/parser-ready": {
@@ -278,7 +278,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "@serialport/parser-regex": {
@@ -288,7 +288,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "@serialport/stream": {
@@ -298,8 +298,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "@serialport/binding-mock": "2.0.5",
-        "debug": "4.1.1"
+        "@serialport/binding-mock": "^2.0.5",
+        "debug": "^4.1.1"
       },
       "dependencies": {
         "debug": {
@@ -309,7 +309,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -327,14 +327,14 @@
       "integrity": "sha512-NOwD9PCIikVRedwMupx1ZZgrmCxuC1G676V12j17XXNKDQUuHDhQGrHXPkJ1shHP7OsdMNhaorDJHYY58S3IPQ==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "debug": "3.1.0",
-        "eventemitter3": "3.0.0",
-        "lodash": "4.17.4",
-        "superagent": "3.8.2",
-        "superagent-promise": "1.1.0",
-        "url": "0.11.0",
-        "ws": "3.3.3"
+        "bluebird": "^3.5.0",
+        "debug": "^3.0.0",
+        "eventemitter3": "^3.0.0",
+        "lodash": "^4.0.1",
+        "superagent": "^3.5.2",
+        "superagent-promise": "^1.0.3",
+        "url": "^0.11.0",
+        "ws": "^3.0.0"
       }
     },
     "@signalk/instrumentpanel": {
@@ -349,11 +349,11 @@
       "integrity": "sha512-F6V/UpN/tQMYiICuE7x78tqLeKU44OYGVV/iW28nDRqTvsAxUTzWlmqShQrqzB00YNIocMC+KhfS8x96U6JRxw==",
       "dev": true,
       "requires": {
-        "@signalk/client": "0.1.4",
-        "d3": "3.5.17",
-        "jquery": "2.2.4",
-        "js-quantities": "1.7.0",
-        "leaflet": "0.7.7"
+        "@signalk/client": "^0.1.1",
+        "d3": "^3.4.13",
+        "jquery": "^2.1.1",
+        "js-quantities": "^1.6.0",
+        "leaflet": "^0.7.3"
       },
       "dependencies": {
         "@signalk/client": {
@@ -362,14 +362,14 @@
           "integrity": "sha1-kzK2P7TLxUyGpXWGcvh9hxTvd4c=",
           "dev": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "debug": "3.1.0",
-            "eventemitter3": "2.0.3",
-            "lodash": "4.17.4",
-            "superagent": "3.8.2",
-            "superagent-promise": "1.1.0",
-            "url": "0.11.0",
-            "ws": "3.3.3"
+            "bluebird": "^3.5.0",
+            "debug": "^3.0.0",
+            "eventemitter3": "^2.0.3",
+            "lodash": "^4.0.1",
+            "superagent": "^3.5.2",
+            "superagent-promise": "^1.0.3",
+            "url": "^0.11.0",
+            "ws": "^3.0.0"
           }
         },
         "eventemitter3": {
@@ -398,7 +398,7 @@
       "integrity": "sha512-0vECxfjb/LbXjyeBHFUJdUiz2L+UO6SxK1qz8P7tPIjn5QV4YqG13kflvgjdl6iB2qQRjd8iMeBAJq9kWUOWCw==",
       "dev": true,
       "requires": {
-        "react-markdown": "4.0.8"
+        "react-markdown": "^4.0.3"
       }
     },
     "@signalk/simplegauges": {
@@ -413,19 +413,19 @@
       "integrity": "sha512-yaP+SRZDKWR4WlzUhocR3MxbMjhss0R0CrIMcs+PgwJgHWHh8Lza88PcLW3Jo4GAhFhxbe2TejT3idBo0y7TcA==",
       "dev": true,
       "requires": {
-        "@canboat/canboatjs": "1.6.5",
-        "@signalk/client": "0.2.1",
-        "@signalk/n2k-signalk": "1.9.1",
-        "@signalk/nmea0183-signalk": "3.3.0",
-        "any-shell-escape": "0.1.1",
-        "aws-sdk": "2.467.0",
-        "file-timestamp-stream": "2.1.3",
-        "lodash": "4.17.4",
-        "mdns": "2.3.4",
-        "node-gpsd": "0.3.0",
-        "reconnect-core": "1.3.0",
-        "serialport": "7.1.5",
-        "stream-throttle": "0.1.3"
+        "@canboat/canboatjs": "^1.4.0",
+        "@signalk/client": "^0.2.0",
+        "@signalk/n2k-signalk": "^1.2.1",
+        "@signalk/nmea0183-signalk": "^3.0.0",
+        "any-shell-escape": "^0.1.1",
+        "aws-sdk": "^2.413.0",
+        "file-timestamp-stream": "^2.1.2",
+        "lodash": "^4.17.4",
+        "mdns": "^2.3.4",
+        "node-gpsd": "^0.3.0",
+        "reconnect-core": "^1.3.0",
+        "serialport": "^7.0.2",
+        "stream-throttle": "^0.1.3"
       },
       "dependencies": {
         "@canboat/canboatjs": {
@@ -434,18 +434,18 @@
           "integrity": "sha512-pppg9BXn5kBkU5ech5uZq0kcAqezCYR825CBi+tbi5wmQd/tuydUJhKrq8it3/+qG9nnGe82x/tws+dfT3/wMw==",
           "dev": true,
           "requires": {
-            "@canboat/pgns": "1.0.8",
+            "@canboat/pgns": "^1.0.4",
             "bit-buffer": "0.2.3",
             "date-fns": "2.0.0-alpha.27",
-            "debug": "3.1.0",
-            "int64-buffer": "0.1.10",
-            "lodash": "4.17.4",
-            "mdns": "2.3.4",
-            "mqtt": "2.18.8",
-            "serialport": "6.2.2",
-            "sleep": "6.1.0",
-            "socketcan": "2.4.0",
-            "split": "1.0.1"
+            "debug": "^3.1.0",
+            "int64-buffer": "^0.1.10",
+            "lodash": "^4.17.4",
+            "mdns": "^2.3.4",
+            "mqtt": "^2.18.8",
+            "serialport": "^6.0.0",
+            "sleep": "^6.0.0",
+            "socketcan": "^2.2.2",
+            "split": "^1.0.1"
           },
           "dependencies": {
             "serialport": {
@@ -455,20 +455,20 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "@serialport/parser-byte-length": "1.0.5",
-                "@serialport/parser-cctalk": "1.0.5",
-                "@serialport/parser-delimiter": "1.0.5",
-                "@serialport/parser-readline": "1.0.5",
-                "@serialport/parser-ready": "1.0.5",
-                "@serialport/parser-regex": "1.0.5",
+                "@serialport/parser-byte-length": "^1.0.5",
+                "@serialport/parser-cctalk": "^1.0.5",
+                "@serialport/parser-delimiter": "^1.0.5",
+                "@serialport/parser-readline": "^1.0.5",
+                "@serialport/parser-ready": "^1.0.5",
+                "@serialport/parser-regex": "^1.0.5",
                 "bindings": "1.3.0",
-                "commander": "2.20.0",
-                "debug": "3.1.0",
-                "nan": "2.14.0",
-                "prebuild-install": "4.0.0",
-                "promirepl": "1.0.1",
-                "prompt-list": "3.2.0",
-                "safe-buffer": "5.1.2"
+                "commander": "^2.13.0",
+                "debug": "^3.1.0",
+                "nan": "^2.9.2",
+                "prebuild-install": "^4.0.0",
+                "promirepl": "^1.0.1",
+                "prompt-list": "^3.2.0",
+                "safe-buffer": "^5.1.2"
               }
             }
           }
@@ -479,9 +479,9 @@
           "integrity": "sha512-ce82JCf36tN/7f0nwyWgEbQeZcRzy/Lg6WvMeQDeAybCw7p6PDXeFeFMYy0aMZ8KG+YF3TdSLtMfHV9F8xVHMg==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.2",
-            "debug": "4.1.1",
-            "through": "2.3.8"
+            "JSONStream": "~1.3.0",
+            "debug": "^4.0.0",
+            "through": ">=2.2.7 <3"
           },
           "dependencies": {
             "debug": {
@@ -490,7 +490,7 @@
               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "dev": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             }
           }
@@ -501,11 +501,11 @@
           "integrity": "sha512-ZA3738mqJkhfMd283eBfM92tAIHK4LYavOWdnBLLEuXbMJ/pceAi3FEKMrHJUjcMOwb9OfOIUUOBEd7/vJhTiQ==",
           "dev": true,
           "requires": {
-            "@signalk/nmea0183-utilities": "0.6.0",
-            "@signalk/signalk-schema": "1.1.1",
-            "ggencoder": "1.0.2",
-            "moment-timezone": "0.5.25",
-            "split": "1.0.1"
+            "@signalk/nmea0183-utilities": "^0.6.0",
+            "@signalk/signalk-schema": "^1.1.1",
+            "ggencoder": "^1.0.2",
+            "moment-timezone": "^0.5.21",
+            "split": "^1.0.1"
           }
         },
         "@signalk/nmea0183-utilities": {
@@ -520,12 +520,12 @@
           "integrity": "sha512-zZ9OYSqP65Ze6lu8YhyC4eGaezSM45K2fte9ey6DeeQfCpb5qKFf8Do/yoqtJB3UWVxcIGlkyt1rICGoDeS3Lg==",
           "dev": true,
           "requires": {
-            "JSONStream": "0.7.4",
-            "debug": "2.6.9",
-            "json-schema-ref-parser": "3.3.1",
-            "lodash": "3.10.1",
-            "tv4": "1.3.0",
-            "tv4-formats": "3.0.3"
+            "JSONStream": "^0.7.4",
+            "debug": "^2.2.0",
+            "json-schema-ref-parser": "^3.1.2",
+            "lodash": "^3.10.1",
+            "tv4": "^1.2.7",
+            "tv4-formats": "^3.0.3"
           },
           "dependencies": {
             "JSONStream": {
@@ -535,7 +535,7 @@
               "dev": true,
               "requires": {
                 "jsonparse": "0.0.5",
-                "through": "2.3.8"
+                "through": ">=2.2.7 <3"
               }
             },
             "debug": {
@@ -581,9 +581,9 @@
           "integrity": "sha512-H7jRZRQItrxjhiRAtbImUY+tmm4Xr1B2IS1EgOyRYzzFaAkPz3wzrMhbO6b8NZA/d10sgySbfO6UuRLuOAcEiw==",
           "dev": true,
           "requires": {
-            "stream.finished": "1.2.0",
-            "tslib": "1.9.3",
-            "ultra-strftime": "1.0.2"
+            "stream.finished": "^1.1.1",
+            "tslib": "^1.9.3",
+            "ultra-strftime": "^1.0.2"
           }
         },
         "ggencoder": {
@@ -611,7 +611,7 @@
           "integrity": "sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==",
           "dev": true,
           "requires": {
-            "moment": "2.20.1"
+            "moment": ">= 2.9.0"
           }
         },
         "ms": {
@@ -634,7 +634,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "semver": "5.5.0"
+            "semver": "^5.4.1"
           }
         },
         "prebuild-install": {
@@ -644,21 +644,21 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "expand-template": "1.1.0",
+            "detect-libc": "^1.0.3",
+            "expand-template": "^1.0.2",
             "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "node-abi": "2.8.0",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "2.0.1",
-            "rc": "1.2.4",
-            "simple-get": "2.8.1",
-            "tar-fs": "1.16.0",
-            "tunnel-agent": "0.6.0",
-            "which-pm-runs": "1.0.0"
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "node-abi": "^2.2.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "os-homedir": "^1.0.1",
+            "pump": "^2.0.1",
+            "rc": "^1.1.6",
+            "simple-get": "^2.7.0",
+            "tar-fs": "^1.13.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
           }
         },
         "pump": {
@@ -668,8 +668,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "safe-buffer": {
@@ -686,16 +686,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "@serialport/binding-mock": "2.0.5",
-            "@serialport/bindings": "2.0.8",
-            "@serialport/parser-byte-length": "2.0.2",
-            "@serialport/parser-cctalk": "2.0.2",
-            "@serialport/parser-delimiter": "2.0.2",
-            "@serialport/parser-readline": "2.0.2",
-            "@serialport/parser-ready": "2.0.2",
-            "@serialport/parser-regex": "2.0.2",
-            "@serialport/stream": "2.0.5",
-            "debug": "4.1.1"
+            "@serialport/binding-mock": "^2.0.5",
+            "@serialport/bindings": "^2.0.8",
+            "@serialport/parser-byte-length": "^2.0.2",
+            "@serialport/parser-cctalk": "^2.0.2",
+            "@serialport/parser-delimiter": "^2.0.2",
+            "@serialport/parser-readline": "^2.0.2",
+            "@serialport/parser-ready": "^2.0.2",
+            "@serialport/parser-regex": "^2.0.2",
+            "@serialport/stream": "^2.0.5",
+            "debug": "^4.1.1"
           },
           "dependencies": {
             "@serialport/parser-byte-length": {
@@ -725,7 +725,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "@serialport/parser-delimiter": "2.0.2"
+                "@serialport/parser-delimiter": "^2.0.2"
               }
             },
             "@serialport/parser-ready": {
@@ -749,7 +749,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             }
           }
@@ -761,9 +761,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "decompress-response": "3.3.0",
-            "once": "1.4.0",
-            "simple-concat": "1.0.0"
+            "decompress-response": "^3.3.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
           }
         },
         "tv4-formats": {
@@ -772,8 +772,8 @@
           "integrity": "sha1-a3l43S3IqjnQrCWU3dtvbAy/2SE=",
           "dev": true,
           "requires": {
-            "moment": "2.20.1",
-            "validator": "8.2.0"
+            "moment": "^2.10.6",
+            "validator": "^8.2.0"
           }
         },
         "validator": {
@@ -791,7 +791,7 @@
       "dev": true,
       "requires": {
         "@signalk/signalk-schema": "1.0.2",
-        "baconjs": "0.7.95"
+        "baconjs": "^0.7.88"
       },
       "dependencies": {
         "@signalk/signalk-schema": {
@@ -800,12 +800,12 @@
           "integrity": "sha512-qU9T/qZfO/lW2+4kZbm0UCcKmrWv6dZMYp1XtFl1WSxrqHwPO5ctKJFhKFe4f2S2MpaUiXYF9MSTQtMHf6mNKQ==",
           "dev": true,
           "requires": {
-            "JSONStream": "0.7.4",
-            "debug": "2.6.9",
-            "json-schema-ref-parser": "3.3.1",
-            "lodash": "3.10.1",
-            "tv4": "1.3.0",
-            "tv4-formats": "2.2.2"
+            "JSONStream": "^0.7.4",
+            "debug": "^2.2.0",
+            "json-schema-ref-parser": "^3.1.2",
+            "lodash": "^3.10.1",
+            "tv4": "^1.2.7",
+            "tv4-formats": "^2.2.1"
           }
         },
         "JSONStream": {
@@ -815,7 +815,7 @@
           "dev": true,
           "requires": {
             "jsonparse": "0.0.5",
-            "through": "2.3.8"
+            "through": ">=2.2.7 <3"
           }
         },
         "debug": {
@@ -847,8 +847,8 @@
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "accepts": {
@@ -857,7 +857,7 @@
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.17",
+        "mime-types": "~2.1.16",
         "negotiator": "0.6.1"
       }
     },
@@ -867,9 +867,9 @@
       "integrity": "sha1-rrooLO53MT6FJAFj1p41sp421iY=",
       "dev": true,
       "requires": {
-        "millisecond": "0.1.2",
-        "setheader": "0.0.4",
-        "vary": "1.1.2"
+        "millisecond": "0.1.x",
+        "setheader": "0.0.x",
+        "vary": "1.1.x"
       }
     },
     "ansi-bgblack": {
@@ -977,33 +977,33 @@
       "integrity": "sha1-csMd4qDZoszQysMMyYI+6y9kNLU=",
       "dev": true,
       "requires": {
-        "ansi-bgblack": "0.1.1",
-        "ansi-bgblue": "0.1.1",
-        "ansi-bgcyan": "0.1.1",
-        "ansi-bggreen": "0.1.1",
-        "ansi-bgmagenta": "0.1.1",
-        "ansi-bgred": "0.1.1",
-        "ansi-bgwhite": "0.1.1",
-        "ansi-bgyellow": "0.1.1",
-        "ansi-black": "0.1.1",
-        "ansi-blue": "0.1.1",
-        "ansi-bold": "0.1.1",
-        "ansi-cyan": "0.1.1",
-        "ansi-dim": "0.1.1",
-        "ansi-gray": "0.1.1",
-        "ansi-green": "0.1.1",
-        "ansi-grey": "0.1.1",
-        "ansi-hidden": "0.1.1",
-        "ansi-inverse": "0.1.1",
-        "ansi-italic": "0.1.1",
-        "ansi-magenta": "0.1.1",
-        "ansi-red": "0.1.1",
-        "ansi-reset": "0.1.1",
-        "ansi-strikethrough": "0.1.1",
-        "ansi-underline": "0.1.1",
-        "ansi-white": "0.1.1",
-        "ansi-yellow": "0.1.1",
-        "lazy-cache": "2.0.2"
+        "ansi-bgblack": "^0.1.1",
+        "ansi-bgblue": "^0.1.1",
+        "ansi-bgcyan": "^0.1.1",
+        "ansi-bggreen": "^0.1.1",
+        "ansi-bgmagenta": "^0.1.1",
+        "ansi-bgred": "^0.1.1",
+        "ansi-bgwhite": "^0.1.1",
+        "ansi-bgyellow": "^0.1.1",
+        "ansi-black": "^0.1.1",
+        "ansi-blue": "^0.1.1",
+        "ansi-bold": "^0.1.1",
+        "ansi-cyan": "^0.1.1",
+        "ansi-dim": "^0.1.1",
+        "ansi-gray": "^0.1.1",
+        "ansi-green": "^0.1.1",
+        "ansi-grey": "^0.1.1",
+        "ansi-hidden": "^0.1.1",
+        "ansi-inverse": "^0.1.1",
+        "ansi-italic": "^0.1.1",
+        "ansi-magenta": "^0.1.1",
+        "ansi-red": "^0.1.1",
+        "ansi-reset": "^0.1.1",
+        "ansi-strikethrough": "^0.1.1",
+        "ansi-underline": "^0.1.1",
+        "ansi-white": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "lazy-cache": "^2.0.1"
       }
     },
     "ansi-cyan": {
@@ -1131,7 +1131,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       },
       "dependencies": {
         "color-convert": {
@@ -1195,8 +1195,8 @@
       "resolved": "https://registry.npmjs.org/application-config/-/application-config-0.1.2.tgz",
       "integrity": "sha1-MnJTO1+fg7MjqeXWQKNVi1Cls4U=",
       "requires": {
-        "application-config-path": "0.1.0",
-        "mkdirp": "0.5.1"
+        "application-config-path": "^0.1.0",
+        "mkdirp": "^0.5.1"
       }
     },
     "application-config-path": {
@@ -1214,8 +1214,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -1224,7 +1224,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-flatten": {
@@ -1240,7 +1240,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-number": "3.0.0"
+        "is-number": "^3.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -1250,7 +1250,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         }
       }
@@ -1337,7 +1337,7 @@
       "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
       "dev": true,
       "requires": {
-        "precond": "0.2.3"
+        "precond": "0.2"
       }
     },
     "baconjs": {
@@ -1395,7 +1395,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.5"
       }
     },
     "bluebird": {
@@ -1411,15 +1411,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "debug": {
@@ -1439,7 +1439,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1455,9 +1455,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-equal-constant-time": {
@@ -1490,8 +1490,8 @@
       "integrity": "sha1-RwGlEmbwbgbqpx/BcjOCLYdfSQg=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "^2.0.1",
+        "readable-stream": "> 1.0.0 < 3.0.0"
       }
     },
     "canboatjs": {
@@ -1499,13 +1499,13 @@
       "resolved": "https://registry.npmjs.org/canboatjs/-/canboatjs-0.0.9.tgz",
       "integrity": "sha512-f7yJv9ehRpBwx7q5VpVEZmXQhwgJFJvDO5ySEbcPofBzUILzD+jbK0q9MLMnpgoQlTpbS/wFRARSbCqb492DeA==",
       "requires": {
-        "bit-buffer": "0.2.3",
-        "debug": "3.1.0",
-        "int64-buffer": "0.1.10",
-        "lodash": "4.17.4",
-        "serialport": "6.0.4",
-        "socketcan": "2.4.0",
-        "split": "1.0.1"
+        "bit-buffer": "^0.2.3",
+        "debug": "^3.1.0",
+        "int64-buffer": "^0.1.10",
+        "lodash": "^4.17.4",
+        "serialport": "^6.0.0",
+        "socketcan": "^2.2.2",
+        "split": "^1.0.1"
       }
     },
     "chai": {
@@ -1514,12 +1514,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.7"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       },
       "dependencies": {
         "deep-eql": {
@@ -1528,7 +1528,7 @@
           "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
           "dev": true,
           "requires": {
-            "type-detect": "4.0.7"
+            "type-detect": "^4.0.0"
           }
         },
         "type-detect": {
@@ -1545,9 +1545,9 @@
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "has-flag": {
@@ -1562,7 +1562,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -1610,9 +1610,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "ansi-dim": "0.1.1",
-        "debug": "2.6.9",
-        "strip-color": "0.1.0"
+        "ansi-dim": "^0.1.1",
+        "debug": "^2.6.6",
+        "strip-color": "^0.1.0"
       },
       "dependencies": {
         "debug": {
@@ -1644,7 +1644,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-truncate": {
@@ -1654,7 +1654,7 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       }
     },
     "cli-width": {
@@ -1670,10 +1670,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "for-own": "1.0.0",
-        "is-plain-object": "2.0.4",
-        "kind-of": "5.1.0",
-        "shallow-clone": "1.0.0"
+        "for-own": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^5.0.0",
+        "shallow-clone": "^1.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -1703,8 +1703,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color": {
@@ -1713,8 +1713,8 @@
       "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
       "dev": true,
       "requires": {
-        "color-convert": "0.5.3",
-        "color-string": "0.3.0"
+        "color-convert": "^0.5.0",
+        "color-string": "^0.3.0"
       }
     },
     "color-convert": {
@@ -1735,7 +1735,7 @@
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.0.0"
       }
     },
     "colornames": {
@@ -1750,8 +1750,8 @@
       "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
       "dev": true,
       "requires": {
-        "color": "0.8.0",
-        "text-hex": "0.0.0"
+        "color": "0.8.x",
+        "text-hex": "0.0.x"
       }
     },
     "combined-stream": {
@@ -1760,7 +1760,7 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "command-exists": {
@@ -1780,8 +1780,8 @@
       "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
       "dev": true,
       "requires": {
-        "leven": "2.1.0",
-        "minimist": "1.2.0"
+        "leven": "^2.1.0",
+        "minimist": "^1.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -1810,7 +1810,7 @@
       "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
       "dev": true,
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": ">= 1.40.0 < 2"
       },
       "dependencies": {
         "mime-db": {
@@ -1827,13 +1827,13 @@
       "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
       "dev": true,
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.5",
         "bytes": "3.0.0",
-        "compressible": "2.0.17",
+        "compressible": "~2.0.16",
         "debug": "2.6.9",
-        "on-headers": "1.0.2",
+        "on-headers": "~1.0.2",
         "safe-buffer": "5.1.2",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "accepts": {
@@ -1842,7 +1842,7 @@
           "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
           "dev": true,
           "requires": {
-            "mime-types": "2.1.24",
+            "mime-types": "~2.1.24",
             "negotiator": "0.6.2"
           }
         },
@@ -1902,10 +1902,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "connected": {
@@ -1982,8 +1982,8 @@
       "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "vary": "1.1.2"
+        "object-assign": "^4",
+        "vary": "^1"
       }
     },
     "create-server": {
@@ -1992,7 +1992,7 @@
       "integrity": "sha1-FkNCg08Yi77Hx7xGZ0Y8wrEwTEQ=",
       "dev": true,
       "requires": {
-        "connected": "0.0.2"
+        "connected": "0.0.x"
       }
     },
     "crypt": {
@@ -2012,7 +2012,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.50"
+        "es5-ext": "^0.10.9"
       }
     },
     "d3": {
@@ -2042,7 +2042,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "mimic-response": "1.0.1"
+        "mimic-response": "^1.0.0"
       }
     },
     "deep-extend": {
@@ -2062,7 +2062,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.12"
       },
       "dependencies": {
         "object-keys": {
@@ -2079,7 +2079,7 @@
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2"
+        "is-descriptor": "^1.0.0"
       }
     },
     "delayed-stream": {
@@ -2128,9 +2128,9 @@
       "integrity": "sha1-4QkJALSVI+hSe+IPCBJ1IF8q42o=",
       "dev": true,
       "requires": {
-        "colorspace": "1.0.1",
-        "enabled": "1.0.2",
-        "kuler": "0.0.0"
+        "colorspace": "1.0.x",
+        "enabled": "1.0.x",
+        "kuler": "0.0.x"
       }
     },
     "diff": {
@@ -2145,8 +2145,8 @@
       "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.1",
-        "entities": "1.1.2"
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
       }
     },
     "domelementtype": {
@@ -2161,7 +2161,7 @@
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.1"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -2170,8 +2170,8 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.1",
-        "domelementtype": "1.3.1"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "duplexer2": {
@@ -2179,7 +2179,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.9"
       },
       "dependencies": {
         "isarray": {
@@ -2192,10 +2192,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -2211,10 +2211,10 @@
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ee-first": {
@@ -2241,7 +2241,7 @@
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "dev": true,
       "requires": {
-        "env-variable": "0.0.3"
+        "env-variable": "0.0.x"
       }
     },
     "encodeurl": {
@@ -2255,7 +2255,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "entities": {
@@ -2282,8 +2282,8 @@
       "integrity": "sha1-6rpkyl1UKjEayUX1gt78M2Fl2fQ=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.4",
-        "escape-html": "1.0.3"
+        "accepts": "~1.3.3",
+        "escape-html": "~1.0.3"
       }
     },
     "es5-ext": {
@@ -2292,9 +2292,9 @@
       "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
       }
     },
     "es6-iterator": {
@@ -2303,9 +2303,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.50",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -2314,12 +2314,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.50",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-promise": {
@@ -2334,11 +2334,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.50",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -2347,8 +2347,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.50"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "escape-html": {
@@ -2375,8 +2375,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.50"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "eventemitter3": {
@@ -2402,7 +2402,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.3"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "express": {
@@ -2411,36 +2411,36 @@
       "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.0",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
+        "proxy-addr": "~2.0.2",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.1",
         "serve-static": "1.13.1",
         "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "debug": {
@@ -2495,7 +2495,7 @@
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "requires": {
-        "is-extendable": "0.1.1"
+        "is-extendable": "^0.1.0"
       }
     },
     "extendible": {
@@ -2510,9 +2510,9 @@
       "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "0.7.0",
-        "iconv-lite": "0.4.24",
-        "tmp": "0.0.33"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       },
       "dependencies": {
         "iconv-lite": {
@@ -2521,7 +2521,7 @@
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         }
       }
@@ -2538,7 +2538,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-uri-to-path": {
@@ -2555,12 +2555,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -2600,7 +2600,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -2614,9 +2614,9 @@
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "format-util": {
@@ -2631,7 +2631,7 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "samsam": "1.x"
       }
     },
     "formidable": {
@@ -2676,8 +2676,8 @@
       "integrity": "sha1-VQwV12r5Jld4qgUezkTUAAoJjUU=",
       "dev": true,
       "requires": {
-        "emits": "3.0.0",
-        "predefine": "0.1.2"
+        "emits": "3.0.x",
+        "predefine": "0.1.x"
       }
     },
     "gauge": {
@@ -2685,14 +2685,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "geolib": {
@@ -2721,12 +2721,12 @@
       "resolved": "https://registry.npmjs.org/ghauth/-/ghauth-3.0.0.tgz",
       "integrity": "sha1-gpKiTvR4mfGAo5x4DEgJVhKUvbw=",
       "requires": {
-        "application-config": "0.1.2",
-        "bl": "0.9.5",
-        "hyperquest": "1.2.0",
-        "mkdirp": "0.5.1",
-        "read": "1.0.7",
-        "xtend": "4.0.1"
+        "application-config": "~0.1.1",
+        "bl": "~0.9.4",
+        "hyperquest": "~1.2.0",
+        "mkdirp": "~0.5.0",
+        "read": "~1.0.5",
+        "xtend": "~4.0.0"
       },
       "dependencies": {
         "bl": {
@@ -2734,7 +2734,7 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
           "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
           "requires": {
-            "readable-stream": "1.0.34"
+            "readable-stream": "~1.0.26"
           }
         },
         "isarray": {
@@ -2747,10 +2747,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -2801,7 +2801,7 @@
           "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.5.tgz",
           "integrity": "sha1-odVBCnLBil8pPyouYocKgK1DLa4=",
           "requires": {
-            "moment": "2.20.1"
+            "moment": ">= 2.6.0"
           }
         },
         "nomnom": {
@@ -2809,8 +2809,8 @@
           "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
           "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
           "requires": {
-            "colors": "0.5.1",
-            "underscore": "1.4.4"
+            "colors": "0.5.x",
+            "underscore": "~1.4.4"
           }
         },
         "semver": {
@@ -2830,10 +2830,10 @@
       "resolved": "https://registry.npmjs.org/github-commit-stream/-/github-commit-stream-0.1.0.tgz",
       "integrity": "sha1-2823smeWcYa3DMc2ORgw2mNo16E=",
       "requires": {
-        "async": "0.2.10",
-        "parse-link-header": "0.1.0",
-        "request": "2.22.0",
-        "through": "2.3.8"
+        "async": "~0.2.9",
+        "parse-link-header": "~0.1.0",
+        "request": "~2.22.0",
+        "through": "~2.3.4"
       },
       "dependencies": {
         "asn1": {
@@ -2856,7 +2856,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
           "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
           "requires": {
-            "hoek": "0.9.1"
+            "hoek": "0.9.x"
           },
           "dependencies": {
             "hoek": {
@@ -2879,7 +2879,7 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
           "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
           "requires": {
-            "boom": "0.4.2"
+            "boom": "0.4.x"
           }
         },
         "delayed-stream": {
@@ -2897,9 +2897,9 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.8.tgz",
           "integrity": "sha1-CJDNEAXFzOzAudJKiAUskkQtDbU=",
           "requires": {
-            "async": "0.2.10",
-            "combined-stream": "0.0.7",
-            "mime": "1.2.11"
+            "async": "~0.2.7",
+            "combined-stream": "~0.0.4",
+            "mime": "~1.2.2"
           }
         },
         "hawk": {
@@ -2907,10 +2907,10 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.13.1.tgz",
           "integrity": "sha1-NheViCH1gxHk1/beKR/KZitBLvQ=",
           "requires": {
-            "boom": "0.4.2",
-            "cryptiles": "0.2.2",
-            "hoek": "0.8.5",
-            "sntp": "0.2.4"
+            "boom": "0.4.x",
+            "cryptiles": "0.2.x",
+            "hoek": "0.8.x",
+            "sntp": "0.2.x"
           }
         },
         "hoek": {
@@ -2924,7 +2924,7 @@
           "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
           "requires": {
             "asn1": "0.1.11",
-            "assert-plus": "0.1.5",
+            "assert-plus": "^0.1.5",
             "ctype": "0.5.3"
           }
         },
@@ -2953,18 +2953,18 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.22.0.tgz",
           "integrity": "sha1-uIOnacxKkJVx61AEs0TEPPflFZI=",
           "requires": {
-            "aws-sign": "0.3.0",
-            "cookie-jar": "0.3.0",
-            "forever-agent": "0.5.2",
+            "aws-sign": "~0.3.0",
+            "cookie-jar": "~0.3.0",
+            "forever-agent": "~0.5.0",
             "form-data": "0.0.8",
-            "hawk": "0.13.1",
-            "http-signature": "0.10.1",
-            "json-stringify-safe": "4.0.0",
-            "mime": "1.2.11",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.3.0",
-            "qs": "0.6.6",
-            "tunnel-agent": "0.3.0"
+            "hawk": "~0.13.0",
+            "http-signature": "~0.10.0",
+            "json-stringify-safe": "~4.0.0",
+            "mime": "~1.2.9",
+            "node-uuid": "~1.4.0",
+            "oauth-sign": "~0.3.0",
+            "qs": "~0.6.0",
+            "tunnel-agent": "~0.3.0"
           }
         },
         "sntp": {
@@ -2972,7 +2972,7 @@
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
           "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
           "requires": {
-            "hoek": "0.9.1"
+            "hoek": "0.9.x"
           },
           "dependencies": {
             "hoek": {
@@ -3000,12 +3000,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -3014,8 +3014,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       }
     },
     "glob-stream": {
@@ -3024,16 +3024,16 @@
       "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "glob": "7.1.2",
-        "glob-parent": "3.1.0",
-        "is-negated-glob": "1.0.0",
-        "ordered-read-streams": "1.0.1",
-        "pumpify": "1.5.1",
-        "readable-stream": "2.3.3",
-        "remove-trailing-separator": "1.1.0",
-        "to-absolute-glob": "2.0.2",
-        "unique-stream": "2.3.1"
+        "extend": "^3.0.0",
+        "glob": "^7.1.1",
+        "glob-parent": "^3.1.0",
+        "is-negated-glob": "^1.0.0",
+        "ordered-read-streams": "^1.0.0",
+        "pumpify": "^1.3.5",
+        "readable-stream": "^2.1.5",
+        "remove-trailing-separator": "^1.0.1",
+        "to-absolute-glob": "^2.0.0",
+        "unique-stream": "^2.0.2"
       }
     },
     "global-modules": {
@@ -3042,9 +3042,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "1.0.2",
-        "is-windows": "1.0.2",
-        "resolve-dir": "1.0.1"
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
       }
     },
     "global-prefix": {
@@ -3053,11 +3053,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.3",
-        "ini": "1.3.5",
-        "is-windows": "1.0.2",
-        "which": "1.3.0"
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "graceful-readlink": {
@@ -3084,7 +3084,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -3110,10 +3110,10 @@
       "integrity": "sha1-jy1QjQYAtKRW2i8IZVbn5cBWo8Y=",
       "dev": true,
       "requires": {
-        "callback-stream": "1.1.0",
-        "glob-stream": "6.1.0",
-        "through2": "2.0.5",
-        "xtend": "4.0.1"
+        "callback-stream": "^1.0.2",
+        "glob-stream": "^6.1.0",
+        "through2": "^2.0.1",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -3128,13 +3128,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -3143,7 +3143,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "through2": {
@@ -3152,8 +3152,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -3164,7 +3164,7 @@
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hpack.js": {
@@ -3173,10 +3173,10 @@
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "obuf": "1.1.2",
-        "readable-stream": "2.3.3",
-        "wbuf": "1.7.3"
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
       }
     },
     "html-to-react": {
@@ -3185,11 +3185,11 @@
       "integrity": "sha512-/tWDdb/8Koi/QEP5YUY1653PcDpBnnMblXRhotnTuhFDjI1Fc6Wzox5d4sw73Xk5rM2OdM5np4AYjT/US/Wj7Q==",
       "dev": true,
       "requires": {
-        "domhandler": "2.4.2",
-        "escape-string-regexp": "1.0.5",
-        "htmlparser2": "3.10.1",
-        "lodash.camelcase": "4.3.0",
-        "ramda": "0.26.1"
+        "domhandler": "^2.4.2",
+        "escape-string-regexp": "^1.0.5",
+        "htmlparser2": "^3.10.0",
+        "lodash.camelcase": "^4.3.0",
+        "ramda": "^0.26"
       }
     },
     "htmlparser2": {
@@ -3198,12 +3198,12 @@
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.1",
-        "domhandler": "2.4.2",
-        "domutils": "1.7.0",
-        "entities": "1.1.2",
-        "inherits": "2.0.3",
-        "readable-stream": "3.4.0"
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -3212,9 +3212,9 @@
           "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "string_decoder": "1.2.0",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "string_decoder": {
@@ -3223,7 +3223,7 @@
           "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -3243,7 +3243,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.3.1 < 2"
       },
       "dependencies": {
         "depd": {
@@ -3259,8 +3259,8 @@
       "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz",
       "integrity": "sha1-OeH+9miI3Hzg3sbA3YFPb8iUStU=",
       "requires": {
-        "duplexer2": "0.0.2",
-        "through2": "0.6.5"
+        "duplexer2": "~0.0.2",
+        "through2": "~0.6.3"
       }
     },
     "iconv-lite": {
@@ -3292,8 +3292,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "info-symbol": {
@@ -3318,19 +3318,19 @@
       "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.2.0",
-        "chalk": "2.4.2",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "3.0.3",
-        "figures": "2.0.0",
-        "lodash": "4.17.11",
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rxjs": "6.5.2",
-        "string-width": "2.1.1",
-        "strip-ansi": "5.2.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3357,8 +3357,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -3367,7 +3367,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -3378,7 +3378,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -3413,8 +3413,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "1.0.0",
-        "is-windows": "1.0.2"
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
       }
     },
     "is-accessor-descriptor": {
@@ -3423,7 +3423,7 @@
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3446,8 +3446,8 @@
       "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
       "dev": true,
       "requires": {
-        "is-alphabetical": "1.0.3",
-        "is-decimal": "1.0.3"
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -3462,7 +3462,7 @@
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3485,9 +3485,9 @@
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "1.0.0",
-        "is-data-descriptor": "1.0.0",
-        "kind-of": "6.0.2"
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3515,7 +3515,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -3524,7 +3524,7 @@
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.0"
       }
     },
     "is-hexadecimal": {
@@ -3557,7 +3557,7 @@
       "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.2.0"
+        "symbol-observable": "^1.1.0"
       }
     },
     "is-plain-obj": {
@@ -3572,7 +3572,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-promise": {
@@ -3587,7 +3587,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "1.0.0"
+        "is-unc-path": "^1.0.0"
       }
     },
     "is-stream": {
@@ -3602,7 +3602,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "0.1.2"
+        "unc-path-regex": "^0.1.2"
       }
     },
     "is-whitespace-character": {
@@ -3670,8 +3670,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -3688,12 +3688,12 @@
       "integrity": "sha512-stQTMhec2R/p2L9dH4XXRlpNCP0mY8QrLd/9Kl+8SHJQmwHtE1nDfXH4wbsSM+GkJMl8t92yZbI0OIol432CIQ==",
       "dev": true,
       "requires": {
-        "call-me-maybe": "1.0.1",
-        "debug": "3.1.0",
-        "es6-promise": "4.2.4",
-        "js-yaml": "3.10.0",
-        "ono": "4.0.3",
-        "z-schema": "3.19.0"
+        "call-me-maybe": "^1.0.1",
+        "debug": "^3.0.0",
+        "es6-promise": "^4.1.1",
+        "js-yaml": "^3.9.1",
+        "ono": "^4.0.2",
+        "z-schema": "^3.18.2"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -3726,7 +3726,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "koalas": {
@@ -3750,7 +3750,7 @@
       "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
       "dev": true,
       "requires": {
-        "set-getter": "0.1.0"
+        "set-getter": "^0.1.0"
       }
     },
     "leaflet": {
@@ -3777,15 +3777,15 @@
       "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
       "dev": true,
       "requires": {
-        "@samverschueren/stream-to-observable": "0.3.0",
-        "is-observable": "1.1.0",
-        "is-promise": "2.1.0",
-        "is-stream": "1.1.0",
-        "listr-silent-renderer": "1.1.1",
-        "listr-update-renderer": "0.5.0",
-        "listr-verbose-renderer": "0.5.0",
-        "p-map": "2.1.0",
-        "rxjs": "6.5.2"
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.5.0",
+        "listr-verbose-renderer": "^0.5.0",
+        "p-map": "^2.0.0",
+        "rxjs": "^6.3.3"
       }
     },
     "listr-silent-renderer": {
@@ -3800,14 +3800,14 @@
       "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "elegant-spinner": "1.0.1",
-        "figures": "1.7.0",
-        "indent-string": "3.2.0",
-        "log-symbols": "1.0.2",
-        "log-update": "2.3.0",
-        "strip-ansi": "3.0.1"
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3822,11 +3822,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "figures": {
@@ -3835,8 +3835,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "supports-color": {
@@ -3853,10 +3853,10 @@
       "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "cli-cursor": "2.1.0",
-        "date-fns": "1.30.1",
-        "figures": "2.0.0"
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
       },
       "dependencies": {
         "date-fns": {
@@ -3878,8 +3878,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -3918,9 +3918,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.get": {
@@ -3989,9 +3989,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.once": {
@@ -4006,8 +4006,8 @@
       "integrity": "sha1-vqPdNqzQuKckDXhza1uXxlREozQ=",
       "dev": true,
       "requires": {
-        "ansi-green": "0.1.1",
-        "success-symbol": "0.1.0"
+        "ansi-green": "^0.1.1",
+        "success-symbol": "^0.1.0"
       }
     },
     "log-symbols": {
@@ -4016,7 +4016,7 @@
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4031,11 +4031,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -4052,9 +4052,9 @@
       "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.2.0",
-        "cli-cursor": "2.1.0",
-        "wrap-ansi": "3.0.1"
+        "ansi-escapes": "^3.0.0",
+        "cli-cursor": "^2.0.0",
+        "wrap-ansi": "^3.0.1"
       }
     },
     "log-utils": {
@@ -4063,13 +4063,13 @@
       "integrity": "sha1-pMIXoN2aUFFdm5ICBgkas9TgMc8=",
       "dev": true,
       "requires": {
-        "ansi-colors": "0.2.0",
-        "error-symbol": "0.1.0",
-        "info-symbol": "0.1.0",
-        "log-ok": "0.1.1",
-        "success-symbol": "0.1.0",
-        "time-stamp": "1.1.0",
-        "warning-symbol": "0.1.0"
+        "ansi-colors": "^0.2.0",
+        "error-symbol": "^0.1.0",
+        "info-symbol": "^0.1.0",
+        "log-ok": "^0.1.1",
+        "success-symbol": "^0.1.0",
+        "time-stamp": "^1.0.1",
+        "warning-symbol": "^0.1.0"
       }
     },
     "lolex": {
@@ -4084,8 +4084,13 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.17.1.tgz",
+      "integrity": "sha512-+xo7Pj54xwyEzlMdXzDqm60Ewqbn0QqACwfIo6so9M1idUtYQrD7/PHjEFQQmLCBu8wUe2IDC2jrcJJ3Buk4Pw=="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -4094,7 +4099,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "markdown-escapes": {
@@ -4109,9 +4114,9 @@
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "dev": true,
       "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "1.1.6"
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
       }
     },
     "mdast-add-list-metadata": {
@@ -4130,8 +4135,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bindings": "1.2.1",
-        "nan": "2.3.5"
+        "bindings": "~1.2.1",
+        "nan": "~2.3.0"
       },
       "dependencies": {
         "nan": {
@@ -4185,7 +4190,7 @@
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "mimic-fn": {
@@ -4213,7 +4218,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -4228,8 +4233,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "for-in": "0.1.8",
-        "is-extendable": "0.1.1"
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
       },
       "dependencies": {
         "for-in": {
@@ -4278,11 +4283,11 @@
       "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
       "dev": true,
       "requires": {
-        "basic-auth": "2.0.0",
+        "basic-auth": "~2.0.0",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "on-finished": "2.3.0",
-        "on-headers": "1.0.1"
+        "depd": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -4302,20 +4307,20 @@
       "integrity": "sha512-3h6oHlPY/yWwtC2J3geraYRtVVoRM6wdI+uchF4nvSSafXPZnaKqF8xnX+S22SU/FcgEAgockVIlOaAX3fkMpA==",
       "dev": true,
       "requires": {
-        "commist": "1.1.0",
-        "concat-stream": "1.6.2",
-        "end-of-stream": "1.4.1",
-        "es6-map": "0.1.5",
-        "help-me": "1.1.0",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "mqtt-packet": "5.6.1",
-        "pump": "3.0.0",
-        "readable-stream": "2.3.6",
-        "reinterval": "1.1.0",
-        "split2": "2.2.0",
-        "websocket-stream": "5.5.0",
-        "xtend": "4.0.1"
+        "commist": "^1.0.0",
+        "concat-stream": "^1.6.2",
+        "end-of-stream": "^1.4.1",
+        "es6-map": "^0.1.5",
+        "help-me": "^1.0.1",
+        "inherits": "^2.0.3",
+        "minimist": "^1.2.0",
+        "mqtt-packet": "^5.6.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^2.3.6",
+        "reinterval": "^1.1.0",
+        "split2": "^2.1.1",
+        "websocket-stream": "^5.1.2",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -4336,8 +4341,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "readable-stream": {
@@ -4346,13 +4351,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -4361,7 +4366,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -4372,10 +4377,10 @@
       "integrity": "sha512-eaF9rO2uFrIYEHomJxziuKTDkbWW5psLBaIGCazQSKqYsTaB3n4SpvJ1PexKaDBiPnMLPIFWBIiTYT3IfEJfww==",
       "dev": true,
       "requires": {
-        "bl": "1.2.1",
-        "inherits": "2.0.3",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1"
+        "bl": "^1.2.1",
+        "inherits": "^2.0.3",
+        "process-nextick-args": "^2.0.0",
+        "safe-buffer": "^5.1.0"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -4426,11 +4431,11 @@
       "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
       "dev": true,
       "requires": {
-        "formatio": "1.2.0",
-        "just-extend": "1.1.27",
-        "lolex": "1.6.0",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "formatio": "^1.2.0",
+        "just-extend": "^1.1.26",
+        "lolex": "^1.6.0",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       },
       "dependencies": {
         "isarray": {
@@ -4461,7 +4466,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
       "integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
       "requires": {
-        "semver": "5.5.0"
+        "semver": "^5.4.1"
       }
     },
     "node-fetch": {
@@ -4491,10 +4496,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -4514,9 +4519,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -4526,7 +4531,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -4536,7 +4541,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-data-descriptor": {
@@ -4546,7 +4551,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-descriptor": {
@@ -4556,9 +4561,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -4577,9 +4582,9 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz",
       "integrity": "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=",
       "requires": {
-        "foreach": "2.0.5",
-        "indexof": "0.0.1",
-        "is": "0.2.7"
+        "foreach": "~2.0.1",
+        "indexof": "~0.0.1",
+        "is": "~0.2.6"
       }
     },
     "object-visit": {
@@ -4588,7 +4593,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "obuf": {
@@ -4617,7 +4622,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -4626,7 +4631,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "ono": {
@@ -4635,7 +4640,7 @@
       "integrity": "sha512-7QIxG4UB00H7CR7fhXC/U7VhB5DK9wsYLwaYBui1JmQoXtLkhIBn3fbuk6FgAP+ctWeBsWVTM+R/bThvUZN+ww==",
       "dev": true,
       "requires": {
-        "format-util": "1.0.3"
+        "format-util": "^1.0.3"
       }
     },
     "ordered-read-streams": {
@@ -4644,7 +4649,7 @@
       "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.1"
       }
     },
     "os-homedir": {
@@ -4670,12 +4675,12 @@
       "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
       "dev": true,
       "requires": {
-        "character-entities": "1.2.3",
-        "character-entities-legacy": "1.1.3",
-        "character-reference-invalid": "1.1.3",
-        "is-alphanumerical": "1.0.3",
-        "is-decimal": "1.0.3",
-        "is-hexadecimal": "1.0.3"
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "parse-link-header": {
@@ -4683,7 +4688,7 @@
       "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-0.1.0.tgz",
       "integrity": "sha1-VQP6f7LzVLsjQlXBxCHaPrBbkYU=",
       "requires": {
-        "xtend": "2.0.6"
+        "xtend": "~2.0.5"
       },
       "dependencies": {
         "xtend": {
@@ -4691,8 +4696,8 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz",
           "integrity": "sha1-XqZXptukRwacLlnFihE4ywxebO4=",
           "requires": {
-            "is-object": "0.1.2",
-            "object-keys": "0.2.0"
+            "is-object": "~0.1.2",
+            "object-keys": "~0.2.0"
           }
         }
       }
@@ -4739,10 +4744,10 @@
       "integrity": "sha512-hT7GwvQL35+0iqgYUl8vn5I5pAVR0HcJas07TXL8bNaR4c5kAFRquk4ZqQk1F9YMcQOr6WjGdY5OnDC0RBnzig==",
       "dev": true,
       "requires": {
-        "md5": "2.2.1",
-        "os-tmpdir": "1.0.2",
-        "safe-buffer": "5.1.1",
-        "which": "1.3.0"
+        "md5": "^2.2.1",
+        "os-tmpdir": "^1.0.1",
+        "safe-buffer": "^5.1.1",
+        "which": "^1.2.4"
       }
     },
     "please-upgrade-node": {
@@ -4751,7 +4756,7 @@
       "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
       "dev": true,
       "requires": {
-        "semver-compare": "1.0.0"
+        "semver-compare": "^1.0.0"
       }
     },
     "pointer-symbol": {
@@ -4766,20 +4771,20 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.0.tgz",
       "integrity": "sha512-3wlyZgmkeeyduOR8Ursu5gKr3yWAYObACa5aJOtt2farRRFV/+zXk/Y3wM6yQRMqmqHh+pHAwyKp5r82K699Rg==",
       "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "1.1.0",
+        "detect-libc": "^1.0.3",
+        "expand-template": "^1.0.2",
         "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.1.2",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "1.0.3",
-        "rc": "1.2.4",
-        "simple-get": "1.4.3",
-        "tar-fs": "1.16.0",
-        "tunnel-agent": "0.6.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-abi": "^2.1.1",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^1.0.1",
+        "rc": "^1.1.6",
+        "simple-get": "^1.4.2",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
         "xtend": "4.0.1"
       },
       "dependencies": {
@@ -4802,7 +4807,7 @@
       "integrity": "sha1-KqkrRJa8H4VU5DpF92v75Q0z038=",
       "dev": true,
       "requires": {
-        "extendible": "0.1.1"
+        "extendible": "0.1.x"
       }
     },
     "primus": {
@@ -4811,16 +4816,16 @@
       "integrity": "sha512-PXogAiNJ6Dmjmx4ODz+uwzNmUZU7IWj6uvVKKnoijRpsTV10aSeHkaFfIfq+kVIrdagOmz5k3HOR5NP9OCtpZw==",
       "dev": true,
       "requires": {
-        "access-control": "1.0.0",
-        "asyncemit": "3.0.1",
-        "create-server": "1.0.1",
-        "diagnostics": "1.1.0",
-        "eventemitter3": "3.0.0",
-        "forwarded-for": "1.0.1",
-        "fusing": "1.0.0",
-        "setheader": "0.0.4",
-        "ultron": "1.1.1",
-        "yeast": "0.1.2"
+        "access-control": "~1.0.0",
+        "asyncemit": "~3.0.1",
+        "create-server": "~1.0.1",
+        "diagnostics": "~1.1.0",
+        "eventemitter3": "~3.0.0",
+        "forwarded-for": "~1.0.1",
+        "fusing": "~1.0.0",
+        "setheader": "~0.0.4",
+        "ultron": "~1.1.0",
+        "yeast": "~0.1.2"
       }
     },
     "process-nextick-args": {
@@ -4840,7 +4845,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "debug": "2.6.9"
+        "debug": "^2.6.8"
       },
       "dependencies": {
         "debug": {
@@ -4862,15 +4867,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "3.1.0",
-        "koalas": "1.0.2",
-        "log-utils": "0.2.1",
-        "prompt-actions": "3.0.2",
-        "prompt-question": "5.0.2",
-        "readline-ui": "2.2.3",
-        "readline-utils": "2.2.3",
-        "static-extend": "0.1.2"
+        "component-emitter": "^1.2.1",
+        "debug": "^3.0.1",
+        "koalas": "^1.0.2",
+        "log-utils": "^0.2.1",
+        "prompt-actions": "^3.0.2",
+        "prompt-question": "^5.0.1",
+        "readline-ui": "^2.2.3",
+        "readline-utils": "^2.2.3",
+        "static-extend": "^0.1.2"
       }
     },
     "prompt-checkbox": {
@@ -4880,9 +4885,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "ansi-cyan": "0.1.1",
-        "debug": "2.6.9",
-        "prompt-base": "4.1.0"
+        "ansi-cyan": "^0.1.1",
+        "debug": "^2.6.8",
+        "prompt-base": "^4.0.2"
       },
       "dependencies": {
         "debug": {
@@ -4904,22 +4909,22 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "arr-swap": "1.0.1",
-        "choices-separator": "2.0.0",
-        "clone-deep": "4.0.1",
-        "collection-visit": "1.0.0",
-        "define-property": "2.0.2",
-        "is-number": "6.0.0",
-        "kind-of": "6.0.2",
-        "koalas": "1.0.2",
-        "log-utils": "0.2.1",
-        "pointer-symbol": "1.0.0",
-        "radio-symbol": "2.0.0",
-        "set-value": "3.0.0",
-        "strip-color": "0.1.0",
-        "terminal-paginator": "2.0.2",
-        "toggle-array": "1.0.1"
+        "arr-flatten": "^1.1.0",
+        "arr-swap": "^1.0.1",
+        "choices-separator": "^2.0.0",
+        "clone-deep": "^4.0.0",
+        "collection-visit": "^1.0.0",
+        "define-property": "^2.0.2",
+        "is-number": "^6.0.0",
+        "kind-of": "^6.0.2",
+        "koalas": "^1.0.2",
+        "log-utils": "^0.2.1",
+        "pointer-symbol": "^1.0.0",
+        "radio-symbol": "^2.0.0",
+        "set-value": "^3.0.0",
+        "strip-color": "^0.1.0",
+        "terminal-paginator": "^2.0.2",
+        "toggle-array": "^1.0.1"
       },
       "dependencies": {
         "clone-deep": {
@@ -4929,9 +4934,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-plain-object": "2.0.4",
-            "kind-of": "6.0.2",
-            "shallow-clone": "3.0.1"
+            "is-plain-object": "^2.0.4",
+            "kind-of": "^6.0.2",
+            "shallow-clone": "^3.0.0"
           }
         },
         "define-property": {
@@ -4941,8 +4946,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           }
         },
         "kind-of": {
@@ -4958,7 +4963,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -4970,9 +4975,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "ansi-cyan": "0.1.1",
-        "ansi-dim": "0.1.1",
-        "prompt-radio": "1.2.1"
+        "ansi-cyan": "^0.1.1",
+        "ansi-dim": "^0.1.1",
+        "prompt-radio": "^1.2.1"
       }
     },
     "prompt-question": {
@@ -4982,13 +4987,13 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "clone-deep": "1.0.0",
-        "debug": "3.1.0",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "kind-of": "5.1.0",
-        "koalas": "1.0.2",
-        "prompt-choices": "4.1.0"
+        "clone-deep": "^1.0.0",
+        "debug": "^3.0.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "kind-of": "^5.0.2",
+        "koalas": "^1.0.2",
+        "prompt-choices": "^4.0.5"
       },
       "dependencies": {
         "kind-of": {
@@ -5007,8 +5012,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "debug": "2.6.9",
-        "prompt-checkbox": "2.2.0"
+        "debug": "^2.6.8",
+        "prompt-checkbox": "^2.2.0"
       },
       "dependencies": {
         "debug": {
@@ -5029,9 +5034,9 @@
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "react-is": "16.8.6"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "proxy-addr": {
@@ -5040,7 +5045,7 @@
       "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.5.2"
       }
     },
@@ -5049,8 +5054,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
       "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -5059,9 +5064,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "3.7.1",
-        "inherits": "2.0.3",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       },
       "dependencies": {
         "pump": {
@@ -5070,8 +5075,8 @@
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -5101,9 +5106,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "ansi-gray": "0.1.1",
-        "ansi-green": "0.1.1",
-        "is-windows": "1.0.2"
+        "ansi-gray": "^0.1.1",
+        "ansi-green": "^0.1.1",
+        "is-windows": "^1.0.1"
       }
     },
     "ramda": {
@@ -5135,10 +5140,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
       "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -5160,13 +5165,13 @@
       "integrity": "sha512-Z6oa648rufvzyO0KwYJ/9p9AsdYGIluqK6OlpJ35ouJ8HPF0Ko1WDNdyymjDSHxNrkb7HDyEcIDJCQs8NlET5A==",
       "dev": true,
       "requires": {
-        "html-to-react": "1.3.4",
+        "html-to-react": "^1.3.4",
         "mdast-add-list-metadata": "1.0.1",
-        "prop-types": "15.7.2",
-        "remark-parse": "5.0.0",
-        "unified": "6.2.0",
-        "unist-util-visit": "1.4.1",
-        "xtend": "4.0.1"
+        "prop-types": "^15.7.2",
+        "remark-parse": "^5.0.0",
+        "unified": "^6.1.5",
+        "unist-util-visit": "^1.3.0",
+        "xtend": "^4.0.1"
       }
     },
     "read": {
@@ -5174,7 +5179,7 @@
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "requires": {
-        "mute-stream": "0.0.7"
+        "mute-stream": "~0.0.4"
       }
     },
     "readable-stream": {
@@ -5182,13 +5187,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readline-ui": {
@@ -5198,10 +5203,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "readline-utils": "2.2.3",
-        "string-width": "2.1.1"
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.8",
+        "readline-utils": "^2.2.1",
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5235,8 +5240,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -5246,7 +5251,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -5257,15 +5262,15 @@
       "integrity": "sha1-b4R9a48ZFcORtYHDZ81HhzhiNRo=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "extend-shallow": "2.0.1",
-        "is-buffer": "1.1.6",
-        "is-number": "3.0.0",
-        "is-windows": "1.0.2",
-        "koalas": "1.0.2",
+        "arr-flatten": "^1.1.0",
+        "extend-shallow": "^2.0.1",
+        "is-buffer": "^1.1.5",
+        "is-number": "^3.0.0",
+        "is-windows": "^1.0.1",
+        "koalas": "^1.0.2",
         "mute-stream": "0.0.7",
-        "strip-color": "0.1.0",
-        "window-size": "1.1.1"
+        "strip-color": "^0.1.0",
+        "window-size": "^1.1.0"
       },
       "dependencies": {
         "is-number": {
@@ -5274,7 +5279,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         }
       }
@@ -5285,7 +5290,7 @@
       "integrity": "sha1-+65SkZp4d9hE4yRtAaLyZwHIM8g=",
       "dev": true,
       "requires": {
-        "backoff": "2.5.0"
+        "backoff": "~2.5.0"
       }
     },
     "reinterval": {
@@ -5300,21 +5305,21 @@
       "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
       "dev": true,
       "requires": {
-        "collapse-white-space": "1.0.5",
-        "is-alphabetical": "1.0.3",
-        "is-decimal": "1.0.3",
-        "is-whitespace-character": "1.0.3",
-        "is-word-character": "1.0.3",
-        "markdown-escapes": "1.0.3",
-        "parse-entities": "1.2.2",
-        "repeat-string": "1.6.1",
-        "state-toggle": "1.0.2",
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.1.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
         "trim": "0.0.1",
-        "trim-trailing-lines": "1.1.2",
-        "unherit": "1.1.2",
-        "unist-util-remove-position": "1.1.3",
-        "vfile-location": "2.0.5",
-        "xtend": "4.0.1"
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -5341,8 +5346,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "global-modules": "1.0.0"
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "restore-cursor": {
@@ -5351,8 +5356,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "run-async": {
@@ -5361,7 +5366,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rxjs": {
@@ -5370,7 +5375,7 @@
       "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -5419,18 +5424,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.2",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
       },
       "dependencies": {
         "debug": {
@@ -5462,12 +5467,12 @@
       "integrity": "sha512-ohiyBppkW0rRbd7CksNSsH8kTx5Fdh1TRL0yp+Yoefgcz12x8j2x+CLsIi23OxSuCTf+tJ9SjJSh93wzTl6tEw==",
       "requires": {
         "bindings": "1.3.0",
-        "commander": "2.11.0",
-        "debug": "3.1.0",
-        "nan": "2.6.2",
-        "prebuild-install": "2.5.0",
-        "promirepl": "1.0.1",
-        "safe-buffer": "5.1.1"
+        "commander": "^2.11.0",
+        "debug": "^3.1.0",
+        "nan": "^2.6.2",
+        "prebuild-install": "^2.2.1",
+        "promirepl": "^1.0.1",
+        "safe-buffer": "^5.0.1"
       },
       "dependencies": {
         "bindings": {
@@ -5483,9 +5488,9 @@
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.1"
       }
     },
@@ -5500,7 +5505,7 @@
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "dev": true,
       "requires": {
-        "to-object-path": "0.3.0"
+        "to-object-path": "^0.3.0"
       }
     },
     "set-value": {
@@ -5510,7 +5515,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-plain-object": "2.0.4"
+        "is-plain-object": "^2.0.4"
       }
     },
     "setheader": {
@@ -5519,7 +5524,7 @@
       "integrity": "sha1-km7SjPdiFJYgkx566j8blYFuxpQ=",
       "dev": true,
       "requires": {
-        "debug": "0.7.4"
+        "debug": "0.7.x"
       },
       "dependencies": {
         "debug": {
@@ -5543,9 +5548,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-extendable": "0.1.1",
-        "kind-of": "5.1.0",
-        "mixin-object": "2.0.1"
+        "is-extendable": "^0.1.1",
+        "kind-of": "^5.0.0",
+        "mixin-object": "^2.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -5568,59 +5573,59 @@
       "integrity": "sha512-iQgvlj5Z5BpTxtXqWTaG7EfZtFuwWKyiu1PR8AMOcetXrDoa49YuBnxYCsX8+VekBdZqkd2eZQ20bD6fAp1mbA==",
       "dev": true,
       "requires": {
-        "@signalk/freeboard-sk": "1.4.0",
-        "@signalk/instrumentpanel": "0.2.5",
-        "@signalk/maptracker": "1.0.0",
-        "@signalk/playground": "1.0.0",
-        "@signalk/sailgauge": "1.1.0",
-        "@signalk/server-admin-ui": "1.12.0",
-        "@signalk/set-system-time": "1.4.0",
+        "@signalk/freeboard-sk": "^1.0.0",
+        "@signalk/instrumentpanel": "0.x",
+        "@signalk/maptracker": "^1.0.0",
+        "@signalk/playground": "^1.0.0",
+        "@signalk/sailgauge": "^1.1.0",
+        "@signalk/server-admin-ui": "1.12.x",
+        "@signalk/set-system-time": "^1.2.0",
         "@signalk/signalk-schema": "1.1.1",
-        "@signalk/signalk-to-nmea0183": "1.5.0",
-        "@signalk/simplegauges": "1.0.1",
-        "@signalk/streams": "1.3.0",
-        "@signalk/zones": "1.0.0",
-        "baconjs": "1.0.1",
-        "bcryptjs": "2.4.3",
-        "body-parser": "1.18.2",
-        "chalk": "2.4.2",
-        "clear": "0.1.0",
-        "command-exists": "1.2.8",
-        "compare-versions": "3.1.0",
-        "compression": "1.7.4",
-        "cookie": "0.3.1",
-        "cookie-parser": "1.4.3",
-        "cors": "2.8.4",
-        "debug": "4.1.1",
-        "deep-get-set": "1.1.0",
+        "@signalk/signalk-to-nmea0183": "^1.0.0",
+        "@signalk/simplegauges": "^1.0.1",
+        "@signalk/streams": "^1.2.0",
+        "@signalk/zones": "^1.0.0",
+        "baconjs": "^1.0.1",
+        "bcryptjs": "^2.4.3",
+        "body-parser": "^1.14.1",
+        "chalk": "^2.4.1",
+        "clear": "^0.1.0",
+        "command-exists": "^1.2.8",
+        "compare-versions": "^3.0.1",
+        "compression": "^1.7.3",
+        "cookie": "^0.3.1",
+        "cookie-parser": "^1.4.3",
+        "cors": "^2.5.2",
+        "debug": "^4.1.0",
+        "deep-get-set": "^1.1.0",
         "dev-null-stream": "0.0.1",
-        "errorhandler": "1.5.0",
-        "express": "4.16.2",
-        "express-namespace": "0.1.1",
-        "figlet": "1.2.3",
-        "file-timestamp-stream": "2.1.3",
+        "errorhandler": "^1.3.0",
+        "express": "^4.10.4",
+        "express-namespace": "^0.1.1",
+        "figlet": "^1.2.0",
+        "file-timestamp-stream": "^2.1.2",
         "flatmap": "0.0.3",
-        "geolib": "2.0.24",
-        "get-installed-path": "4.0.8",
-        "inquirer": "6.3.1",
-        "jsonwebtoken": "8.5.1",
-        "listr": "0.14.3",
-        "lodash": "4.17.4",
-        "mdns": "2.3.4",
-        "minimist": "1.2.0",
-        "moment": "2.20.1",
-        "morgan": "1.9.0",
-        "node-fetch": "2.6.0",
-        "node-gpsd": "0.3.0",
-        "pem": "1.12.3",
-        "please-upgrade-node": "3.1.1",
-        "primus": "7.1.1",
-        "semver": "6.1.1",
-        "spdy": "4.0.0",
-        "split": "1.0.1",
-        "stat-mode": "0.3.0",
-        "uuid": "3.2.1",
-        "ws": "6.2.1"
+        "geolib": "^2.0.24",
+        "get-installed-path": "^4.0.8",
+        "inquirer": "^6.1.0",
+        "jsonwebtoken": "^8.1.1",
+        "listr": "^0.14.1",
+        "lodash": "^4.17.4",
+        "mdns": "^2.3.4",
+        "minimist": "^1.1.0",
+        "moment": "^2.10.6",
+        "morgan": "^1.5.0",
+        "node-fetch": "^2.2.0",
+        "node-gpsd": "^0.3.0",
+        "pem": "^1.11.0",
+        "please-upgrade-node": "^3.0.1",
+        "primus": "^7.0.0",
+        "semver": "^6.0.0",
+        "spdy": "^4.0.0",
+        "split": "^1.0.0",
+        "stat-mode": "^0.3.0",
+        "uuid": "^3.2.1",
+        "ws": "^6.1.1"
       },
       "dependencies": {
         "@signalk/freeboard-sk": {
@@ -5641,12 +5646,12 @@
           "integrity": "sha512-zZ9OYSqP65Ze6lu8YhyC4eGaezSM45K2fte9ey6DeeQfCpb5qKFf8Do/yoqtJB3UWVxcIGlkyt1rICGoDeS3Lg==",
           "dev": true,
           "requires": {
-            "JSONStream": "0.7.4",
-            "debug": "2.6.9",
-            "json-schema-ref-parser": "3.3.1",
-            "lodash": "3.10.1",
-            "tv4": "1.3.0",
-            "tv4-formats": "3.0.3"
+            "JSONStream": "^0.7.4",
+            "debug": "^2.2.0",
+            "json-schema-ref-parser": "^3.1.2",
+            "lodash": "^3.10.1",
+            "tv4": "^1.2.7",
+            "tv4-formats": "^3.0.3"
           },
           "dependencies": {
             "debug": {
@@ -5672,8 +5677,8 @@
           "integrity": "sha512-6+WY6ivjNndB8WKUTCjD43EwjJ66HPwEgkwKWCcGg9wcdFvRHwGbSQNee16JLTqyRLOw/Fsbww5QjVqB/KmkBQ==",
           "dev": true,
           "requires": {
-            "baconjs": "0.7.95",
-            "mocha": "3.5.3"
+            "baconjs": "^0.7.88",
+            "mocha": "^3.5.0"
           },
           "dependencies": {
             "baconjs": {
@@ -5691,7 +5696,7 @@
           "dev": true,
           "requires": {
             "jsonparse": "0.0.5",
-            "through": "2.3.8"
+            "through": ">=2.2.7 <3"
           }
         },
         "baconjs": {
@@ -5706,7 +5711,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "debug": {
@@ -5715,7 +5720,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           },
           "dependencies": {
             "ms": {
@@ -5738,7 +5743,7 @@
           "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "file-timestamp-stream": {
@@ -5747,9 +5752,9 @@
           "integrity": "sha512-H7jRZRQItrxjhiRAtbImUY+tmm4Xr1B2IS1EgOyRYzzFaAkPz3wzrMhbO6b8NZA/d10sgySbfO6UuRLuOAcEiw==",
           "dev": true,
           "requires": {
-            "stream.finished": "1.2.0",
-            "tslib": "1.9.3",
-            "ultra-strftime": "1.0.2"
+            "stream.finished": "^1.1.1",
+            "tslib": "^1.9.3",
+            "ultra-strftime": "^1.0.2"
           }
         },
         "glob": {
@@ -5758,12 +5763,12 @@
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "growl": {
@@ -5790,16 +5795,16 @@
           "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
           "dev": true,
           "requires": {
-            "jws": "3.2.2",
-            "lodash.includes": "4.3.0",
-            "lodash.isboolean": "3.0.3",
-            "lodash.isinteger": "4.0.4",
-            "lodash.isnumber": "3.0.3",
-            "lodash.isplainobject": "4.0.6",
-            "lodash.isstring": "4.0.1",
-            "lodash.once": "4.1.1",
-            "ms": "2.1.1",
-            "semver": "5.7.0"
+            "jws": "^3.2.2",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "semver": "^5.6.0"
           },
           "dependencies": {
             "ms": {
@@ -5824,7 +5829,7 @@
           "requires": {
             "buffer-equal-constant-time": "1.0.1",
             "ecdsa-sig-formatter": "1.0.11",
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "jws": {
@@ -5833,8 +5838,8 @@
           "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
           "dev": true,
           "requires": {
-            "jwa": "1.4.1",
-            "safe-buffer": "5.1.1"
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "minimist": {
@@ -5892,7 +5897,7 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "tv4-formats": {
@@ -5901,8 +5906,8 @@
           "integrity": "sha1-a3l43S3IqjnQrCWU3dtvbAy/2SE=",
           "dev": true,
           "requires": {
-            "moment": "2.20.1",
-            "validator": "8.2.0"
+            "moment": "^2.10.6",
+            "validator": "^8.2.0"
           }
         },
         "validator": {
@@ -5917,7 +5922,7 @@
           "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "dev": true,
           "requires": {
-            "async-limiter": "1.0.0"
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -5934,9 +5939,9 @@
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
       "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
       "requires": {
-        "once": "1.4.0",
-        "unzip-response": "1.0.2",
-        "xtend": "4.0.1"
+        "once": "^1.3.1",
+        "unzip-response": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "sinon": {
@@ -5945,13 +5950,13 @@
       "integrity": "sha512-lx9ZCoScNhvs6+n3ku78CqIpQNIiY9gLfvuIdhZjnKOkcVL6FfWfA1jkOrcO+n3mX4BIg2XwQnyCS/Ive21QMw==",
       "dev": true,
       "requires": {
-        "diff": "3.3.1",
+        "diff": "^3.1.0",
         "formatio": "1.2.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.3.1",
-        "nise": "1.2.0",
-        "supports-color": "5.1.0",
-        "type-detect": "4.0.7"
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.2.0",
+        "nise": "^1.2.0",
+        "supports-color": "^5.1.0",
+        "type-detect": "^4.0.5"
       },
       "dependencies": {
         "supports-color": {
@@ -5960,7 +5965,7 @@
           "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         },
         "type-detect": {
@@ -5977,7 +5982,7 @@
       "integrity": "sha512-Z1x4JjJxsru75Tqn8F4tnOFeEu3HjtITTsumYUiuz54sGKdISgLCek9AUlXlVVrkhltRFhNUsJDJE76SFHTDIQ==",
       "dev": true,
       "requires": {
-        "nan": "2.14.0"
+        "nan": "^2.13.2"
       },
       "dependencies": {
         "nan": {
@@ -6000,8 +6005,8 @@
       "integrity": "sha512-m4qZEgcyUScjxLxnfjopc48tVNxVFyNHiQqgMccQjJ6JOlmDVyXBmrQLxk0snJte066pw6SKpYUNixSwDdyqOQ==",
       "optional": true,
       "requires": {
-        "nan": "2.6.2",
-        "xml2js": "0.4.19"
+        "nan": "*",
+        "xml2js": ">=0.2.0"
       }
     },
     "spdy": {
@@ -6010,11 +6015,11 @@
       "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
       "dev": true,
       "requires": {
-        "debug": "4.1.1",
-        "handle-thing": "2.0.0",
-        "http-deceiver": "1.2.7",
-        "select-hose": "2.0.0",
-        "spdy-transport": "3.0.0"
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -6023,7 +6028,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -6040,12 +6045,12 @@
       "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "dev": true,
       "requires": {
-        "debug": "4.1.1",
-        "detect-node": "2.0.4",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.2",
-        "readable-stream": "3.4.0",
-        "wbuf": "1.7.3"
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
       },
       "dependencies": {
         "debug": {
@@ -6054,7 +6059,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -6069,9 +6074,9 @@
           "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "string_decoder": "1.2.0",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "string_decoder": {
@@ -6080,7 +6085,7 @@
           "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -6090,7 +6095,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split2": {
@@ -6099,7 +6104,7 @@
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
-        "through2": "2.0.5"
+        "through2": "^2.0.2"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -6114,13 +6119,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -6129,7 +6134,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "through2": {
@@ -6138,8 +6143,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -6163,8 +6168,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -6174,7 +6179,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -6184,7 +6189,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6194,7 +6199,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -6206,7 +6211,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6216,7 +6221,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -6228,9 +6233,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -6260,8 +6265,8 @@
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
-        "limiter": "1.1.2"
+        "commander": "^2.2.0",
+        "limiter": "^1.0.5"
       }
     },
     "stream.finished": {
@@ -6270,8 +6275,8 @@
       "integrity": "sha512-xSp45f/glqd035qAtFUxAGvhotjY/EfqDNV+rQW8o7ffligiOjPaguTEvRzeQAhiQMCdkPEBrp5++S/rQyavWQ==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string-width": {
@@ -6279,9 +6284,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -6289,7 +6294,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -6297,7 +6302,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-color": {
@@ -6323,16 +6328,16 @@
       "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
-        "debug": "3.1.0",
-        "extend": "3.0.1",
-        "form-data": "2.3.1",
-        "formidable": "1.1.1",
-        "methods": "1.1.2",
-        "mime": "1.6.0",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.3"
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.1.1",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.0.5"
       }
     },
     "superagent-promise": {
@@ -6347,7 +6352,7 @@
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "symbol-observable": {
@@ -6361,10 +6366,10 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
       "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
       "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.5.5"
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
       }
     },
     "tar-stream": {
@@ -6372,10 +6377,10 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.1",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "terminal-paginator": {
@@ -6385,9 +6390,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "debug": "2.6.9",
-        "extend-shallow": "2.0.1",
-        "log-utils": "0.2.1"
+        "debug": "^2.6.6",
+        "extend-shallow": "^2.0.1",
+        "log-utils": "^0.2.1"
       },
       "dependencies": {
         "debug": {
@@ -6424,8 +6429,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "4.0.1"
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
       },
       "dependencies": {
         "isarray": {
@@ -6438,10 +6443,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -6457,8 +6462,8 @@
       "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
       "dev": true,
       "requires": {
-        "through2": "2.0.5",
-        "xtend": "4.0.1"
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -6473,13 +6478,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -6488,7 +6493,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "through2": {
@@ -6497,8 +6502,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -6515,7 +6520,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-absolute-glob": {
@@ -6524,8 +6529,8 @@
       "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
       "dev": true,
       "requires": {
-        "is-absolute": "1.0.0",
-        "is-negated-glob": "1.0.0"
+        "is-absolute": "^1.0.0",
+        "is-negated-glob": "^1.0.0"
       }
     },
     "to-object-path": {
@@ -6534,7 +6539,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "toggle-array": {
@@ -6544,7 +6549,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "trim": {
@@ -6576,7 +6581,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tv4": {
@@ -6591,8 +6596,8 @@
       "integrity": "sha1-gz2mNt7jtOd85kHRUOYIAY3GW40=",
       "dev": true,
       "requires": {
-        "moment": "2.20.1",
-        "validator": "7.2.0"
+        "moment": "^2.10.6",
+        "validator": "^7.0.0"
       },
       "dependencies": {
         "validator": {
@@ -6610,7 +6615,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "~2.1.15"
       }
     },
     "typedarray": {
@@ -6643,8 +6648,8 @@
       "integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "xtend": "4.0.1"
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.1"
       }
     },
     "unified": {
@@ -6653,12 +6658,12 @@
       "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
       "dev": true,
       "requires": {
-        "bail": "1.0.4",
-        "extend": "3.0.1",
-        "is-plain-obj": "1.1.0",
-        "trough": "1.0.4",
-        "vfile": "2.3.0",
-        "x-is-string": "0.1.0"
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "trough": "^1.0.0",
+        "vfile": "^2.0.0",
+        "x-is-string": "^0.1.0"
       }
     },
     "unique-stream": {
@@ -6667,8 +6672,8 @@
       "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
       "dev": true,
       "requires": {
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "through2-filter": "3.0.0"
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "through2-filter": "^3.0.0"
       }
     },
     "unist-util-is": {
@@ -6683,7 +6688,7 @@
       "integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
       "dev": true,
       "requires": {
-        "unist-util-visit": "1.4.1"
+        "unist-util-visit": "^1.1.0"
       }
     },
     "unist-util-stringify-position": {
@@ -6698,7 +6703,7 @@
       "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
       "dev": true,
       "requires": {
-        "unist-util-visit-parents": "2.1.2"
+        "unist-util-visit-parents": "^2.0.0"
       },
       "dependencies": {
         "unist-util-visit-parents": {
@@ -6707,7 +6712,7 @@
           "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
           "dev": true,
           "requires": {
-            "unist-util-is": "3.0.0"
+            "unist-util-is": "^3.0.0"
           }
         }
       }
@@ -6774,10 +6779,10 @@
       "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6",
+        "is-buffer": "^1.1.4",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "1.1.2",
-        "vfile-message": "1.1.1"
+        "unist-util-stringify-position": "^1.0.0",
+        "vfile-message": "^1.0.0"
       }
     },
     "vfile-location": {
@@ -6792,7 +6797,7 @@
       "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
       "dev": true,
       "requires": {
-        "unist-util-stringify-position": "1.1.2"
+        "unist-util-stringify-position": "^1.1.1"
       }
     },
     "warning-symbol": {
@@ -6807,7 +6812,7 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "requires": {
-        "minimalistic-assert": "1.0.1"
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "websocket-stream": {
@@ -6816,12 +6821,12 @@
       "integrity": "sha512-EXy/zXb9kNHI07TIMz1oIUIrPZxQRA8aeJ5XYg5ihV8K4kD1DuA+FY6R96HfdIHzlSzS8HiISAfrm+vVQkZBug==",
       "dev": true,
       "requires": {
-        "duplexify": "3.7.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "safe-buffer": "5.1.2",
-        "ws": "3.3.3",
-        "xtend": "4.0.1"
+        "duplexify": "^3.5.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "safe-buffer": "^5.1.2",
+        "ws": "^3.2.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "safe-buffer": {
@@ -6838,7 +6843,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-pm-runs": {
@@ -6853,7 +6858,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "window-size": {
@@ -6862,8 +6867,8 @@
       "integrity": "sha512-5D/9vujkmVQ7pSmc0SCBmHXbkv6eaHwXEx65MywhmUMsI8sGqJ972APq1lotfcwMKPFLuCFfL8xGHLIp7jaBmA==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "is-number": "3.0.0"
+        "define-property": "^1.0.0",
+        "is-number": "^3.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -6872,7 +6877,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         }
       }
@@ -6883,8 +6888,8 @@
       "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0"
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6905,8 +6910,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -6915,7 +6920,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -6931,9 +6936,9 @@
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "x-is-string": {
@@ -6947,8 +6952,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.4"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
@@ -6973,10 +6978,10 @@
       "integrity": "sha512-V94f3ODuluBS4kQLLjNhwoMek0dyIXCsvNu/A17dAyJ6sMhT5KkJQwSn07R0naByLIXJWMDk+ruMfI/3G3hS4Q==",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
-        "lodash.get": "4.4.2",
-        "lodash.isequal": "4.5.0",
-        "validator": "9.2.0"
+        "commander": "^2.7.1",
+        "lodash.get": "^4.0.0",
+        "lodash.isequal": "^4.0.0",
+        "validator": "^9.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "canboatjs": "0.0.9",
     "debug": "^3.1.0",
     "github-changes": "^1.1.2",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "luxon": "^1.17.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates the `systemTime` conversion and adds an `autopilot` conversion, that takes NMEA0183 route data ($ECAPB, $ECXTE, $ECRMB & $ECRMC) converted into Signal K, and passes this on in the format required to generate valid PGNs. 

This is a work in progress as the work needs to be tested on an actual boat before it should be released. Also, many questions remain, related to the PGNs it generates (most data in the Navigation Data PGN is not present). 

Also, since this is tightly coupled to the data sent by OpenCPN at the moment, there is no selection of true or magnetic bearing to waypoint, kind of routing (rhumbline) etc

@sbender9 you have some experience with APs as well, could you review my work so far and post your thoughts?
