### PR TITLE
feature: add support for navigation data (129283, 129284)

### DIFF
--- a/conversions/navigationdata.js
+++ b/conversions/navigationdata.js
@@ -1,0 +1,62 @@
+
+module.exports = (app, plugin) => {
+  return [{
+    pgn: 129283,
+    title: 'Cross Track Error (129283)',
+    optionKey: 'xte',
+    keys: [
+      'navigation.courseRhumbline.crossTrackError'
+    ],
+    callback: (XTE) => [{
+      pgn: 129283,
+      XTE,
+      "XTE mode": "Autonomous",
+      "Navigation Terminated": "No"
+    }]
+  }, {
+    pgn: 129284,
+    title: 'Navigation Data (129284)',
+    optionKey: 'navigationdata',
+    keys: [
+      'navigation.courseRhumbline.nextPoint.distance',
+      'navigation.courseRhumbline.bearingToDestinationTrue',
+      'navigation.courseRhumbline.bearingOriginToDestinationTrue',
+      'navigation.courseRhumbline.nextPoint',
+      'navigation.courseRhumbline.nextPoint.velocityMadeGood',
+      'notifications.arrivalCircleEntered',
+      'notifications.perpendicularPassed',
+      'navigation.courseRhumbline.nextPoint.ID'
+    ],
+    timeouts: [
+      10000, 10000, 10000, 10000, 10000, undefined, undefined, 10000
+    ],
+    callback: (distToDest, bearingToDest, bearingOriginToDest, dest, WCV, ace, pp, wpid) => {
+      var dateObj = new Date();
+      var secondsToGo = Math.trunc(distToDest / WCV);
+      var etaDate = Math.trunc((dateObj.getTime() / 1000 + secondsToGo) / 86400);
+      var etaTime = (dateObj.getUTCHours() * (60 * 60) +
+                     dateObj.getUTCMinutes() * 60 +
+                     dateObj.getUTCSeconds() +
+                     secondsToGo) % 86400;
+
+      return [{
+        pgn: 129284,
+        "SID" : 0x88,
+        "Distance to Waypoint" :  distToDest,
+        "Course/Bearing reference" : 0,
+        "Perpendicular Crossed" : pp != null,
+        "Arrival Circle Entered" : ace != null,
+        "Calculation Type" : 1,
+        "ETA Time" : (WCV > 0) ? etaTime : undefined,
+        "ETA Date": (WCV > 0) ? etaDate : undefined,
+        "Bearing, Origin to Destination Waypoint" : bearingOriginToDest,
+        "Bearing, Position to Destination Waypoint" : bearingToDest,
+        "Origin Waypoint Number" : undefined,
+        "Destination Waypoint Number" : parseInt(wpid),
+        "Destination Latitude" : dest.latitude,
+        "Destination Longitude" : dest.longitude,
+        "Waypoint Closing Velocity" : WCV,
+      }]
+    }
+  }]
+}


### PR DESCRIPTION
Add support for emitting the various PGNs that carry the information
about the distance and bearing to the active waypoint. This should
provide all information needed by autopilots (heading to steer, XTE)
as well as bearing/distance to waypoint and estimated time of arrival,
which is commonly displayed for human consumption.

Tested with OpenCPN as the producer of APB sentences, and a B&G Triton2
display to show the various data items.

This is based on the outdated and incomplete implementation that lives
on the 'autopilot' branch.

Signed-off-by: Ard Biesheuvel <ardb@kernel.org>