### PR TITLE
fix: add missing DC type in PGN 127506

### DIFF
--- a/conversions/battery.js
+++ b/conversions/battery.js
@@ -69,6 +69,7 @@ module.exports = (app, plugin) => {
               res.push({
                 pgn: 127506,
                 "DC Instance": battery.instanceId,
+                "DC Type": "Battery",
                 "Instance": battery.instanceId,
                 'State of Charge': stateOfCharge,
                 'State of Health': stateOfHealth,


### PR DESCRIPTION
Adds missing DC type in PGN 127506 for Raymarine devices. Addresses issue #68.