### PR TITLE
fix: fuel rate conversion for 127489 is incorrect

### DIFF
--- a/conversions/engineParameters.js
+++ b/conversions/engineParameters.js
@@ -112,7 +112,7 @@ module.exports = (app, plugin) => {
                 "Oil temperature": oilTemp === null ? undefined : oilTemp,
                 "Temperature": temp === null ? undefined : temp,
                 "Alternator Potential": altVolt === null ? undefined : altVolt,
-                "Fuel Rate": fuelRate ===null ? undefined : fuelRate / 3600 * 1000,
+                "Fuel Rate": fuelRate ===null ? undefined : fuelRate * 3600 * 1000,
                 "Total Engine hours": runTime === null ? undefined : runTime,
                 "Coolant Pressure": coolPres === null ? undefined : coolPres / 100,
                 "Fuel Pressure": fuelPres === null ? undefined : fuelPres / 100,


### PR DESCRIPTION
Fuel rate in Signal K is expressed in cubic meters per second. PGN 127489 fuel rate is L/h. Conversion should be "* 3600 * 1000". Fixes issue #65.