### PR TITLE
Update tanks.js to report capacity in liters

### DIFF
--- a/conversions/tanks.js
+++ b/conversions/tanks.js
@@ -90,7 +90,7 @@ module.exports = (app, plugin) => {
               return res
             },
             tests: [{
-              input: [ 0.35, 12 ],
+              input: [ 0.35, .012 ],
               expected: [{
                 "prio": 2,
                 "pgn": 127505,

--- a/conversions/tanks.js
+++ b/conversions/tanks.js
@@ -83,7 +83,7 @@ module.exports = (app, plugin) => {
                   "Instance": tank.instanceId,
                   Type: type,
                   Level: currentLevel * 100,
-                  Capacity: capacity
+                  Capacity: capacity * 1000
                 })
               }
               


### PR DESCRIPTION
PGN 127505 should report the tank capacity in liters, not cubic meters as signalk-server stores the value internally. See https://github.com/canboat/canboat/blob/649325e38df1d954b16f6662b2c8bbd3eb5a1ca9/analyzer/pgns.json#L16384

I've tested this locally and the edit results in the correct capacity being displayed on my B&G Zeus 3s chartplotter.