### PR TITLE
feature: new converion that supports true heading messages (PGN 127250).

### DIFF
--- a/conversions/trueheading.js
+++ b/conversions/trueheading.js
@@ -1,0 +1,34 @@
+
+module.exports = (app, plugin) => {
+  return {
+    pgn: 127250,
+    title: 'TrueHeading (127250)',
+    optionKey: 'TRUE_HEADING',
+    keys: [
+      "navigation.headingTrue"
+    ],
+    callback: (heading) => {
+      return [{
+        pgn: 127250,
+        SID: 87,
+        Heading: heading,
+        "Variation": undefined,
+        Reference: "True"
+      }]
+    },
+    tests: [{
+      input: [ 1.35, undefined ],
+      expected: [{
+        "prio": 2,
+        "pgn": 127250,
+        "dst": 255,
+        "fields": {
+          "SID": 87,
+          "Heading": 1.35,
+          "Variation": undefined,
+          "Reference": "True"
+        }
+      }]
+    }]
+  }
+}


### PR DESCRIPTION
New conversion to allow handling of heading messages from TrueHeading devices that should have Reference: True and no variation. Tested on my boat with a NMEA 0183 sending HDT messages that feed into SignalK.
This is my first attempt to write java-script (input) and using GitHub so I might have missed something...