### PR TITLE
feature: add 126720 for Raymarine Display Group Brightness

### DIFF
--- a/conversions/raymarineBrightness.js
+++ b/conversions/raymarineBrightness.js
@@ -1,0 +1,80 @@
+const _ = require('lodash')
+
+module.exports = (app, plugin) => {
+  return {
+    title: 'Raymarine (Seatalk) Display Brightness (126720)',
+    optionKey: 'RAYMARINE',
+    context: 'vessels.self',
+    properties: {
+      groups: {
+        title: 'Group Mapping',
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            signalkId: {
+              title: 'Signal K Group id',
+              type: 'string',
+            },
+            instanceId: {
+              title: 'NMEA2000 Group Instance Id',
+              type: 'string',
+            }
+          }
+        }
+      }
+    },
+
+    testOptions: {
+      RAYMARINE: {
+        groups: [{
+          signalkId: 'helm2',
+          instanceId: 'Helm 2'
+        }]
+      }
+    },
+
+    conversions: (options) => {
+      if (!_.get(options, 'RAYMARINE.groups')) {
+        return null
+      }
+      return options.RAYMARINE.groups.map(group => {
+        return {
+          keys: [`electrical.displays.raymarine.${group.signalkId}.brightness`],
+          callback: (brightness) => {
+            return [{
+              pgn: 126720,
+              "dst": 255,
+              "Manufacturer Code": "Raymarine",
+              "Industry Code": "Marine Industry",
+              "Proprietary ID": "0x0c8c",
+              "Group": group.instanceId,
+              "Unknown 1": 1,
+              "Command": "Brightness",
+              "Brightness": brightness * 100,
+              "Unknown 2": 0
+            }]
+          },
+          tests: [{
+            input: [0.85],
+            expected: [{
+              "prio": 2,
+              "pgn": 126720,
+              "dst": 255,
+              "fields": {
+                "Manufacturer Code": "Raymarine",
+                "Industry Code": "Marine Industry",
+                "Proprietary ID": "0x0c8c",
+                "Group": "Helm 2",
+                "Unknown 1": 1,
+                "Command": "Brightness",
+                "Brightness": 85,
+                "Unknown 2": 0
+              }
+            }]
+          }]
+        }
+      })
+    }
+  }
+}


### PR DESCRIPTION
Allows for the brightness control of a Raymarine Display Group.
Used it myself to set the brightness automatically according to the sun position.

Question: Had to hardcode the ``dst: 255`` value, otherwhise it would somehow default to ``dst: 0`` when sending (despite the tests passing) and the displays did not react. Maybe someone knows a better way to fix this...

Here is a short demo video of manual control in action:

https://github.com/user-attachments/assets/df2df13b-976f-43dd-81ea-05a6251cdfcc
