### PR TITLE
feature: improve 129284 navigationdata PGN generation

### DIFF
--- a/conversions/navigationdata.js
+++ b/conversions/navigationdata.js
@@ -4,6 +4,7 @@ const _ = require('lodash')
 const routeWPDataItemsPerPacket = 3
 
 module.exports = (app, plugin) => {
+  var sid129284 = 0;
   return [{
     pgn: 127258,
     title: 'Magnetic Variation (127258)',
@@ -74,80 +75,92 @@ module.exports = (app, plugin) => {
         }
       }]
     }]
-  }, 
+  },
   {
     pgn: 129284,
     title: 'Navigation Data (129284)',
     optionKey: 'navigationdata',
-    keys: [
-      'navigation.course.calcValues.distance',
-      'navigation.course.calcValues.bearingTrue',
-      'navigation.course.calcValues.bearingTrackTrue',
-      'navigation.course.nextPoint',
-      'navigation.course.calcValues.velocityMadeGood',
-      'navigation.course.calcValues.calcMethod',
-      'notifications.navigation.arrivalCircleEntered',
-      'notifications.navigation.perpendicularPassed',
-      'navigation.course.activeRoute'
-    ],
-    timeouts: [
-      10000, 10000, 10000, 10000, 10000, undefined, undefined, undefined, undefined
-    ],
-    callback: (distToDest, bearingToDest, bearingOriginToDest, destPos, WCV, calcMethod, ace, pp, rte) => {
-      var dateObj = new Date();
-      var secondsToGo = Math.trunc(distToDest / WCV);
-      var etaDate = Math.trunc((dateObj.getTime() / 1000 + secondsToGo) / 86400);
-      var etaTime = (dateObj.getUTCHours() * (60 * 60) +
-                     dateObj.getUTCMinutes() * 60 +
-                     dateObj.getUTCSeconds() +
-                     secondsToGo) % 86400;
-      let wpid = rte && typeof rte?.pointIndex === 'number' ? rte.pointIndex + 1 : 0;
+    conversions: (options) => {
       return [{
-        pgn: 129284,
-        "SID" : 0x88,
-        "Distance to Waypoint" :  distToDest,
-        "Course/Bearing reference" : 0,
-        "Perpendicular Crossed" : pp != null,
-        "Arrival Circle Entered" : ace != null,
-        "Calculation Type" : calcMethod == "GreatCircle" ? 0 : 1,
-        "ETA Time" : (WCV > 0) ? etaTime : undefined,
-        "ETA Date": (WCV > 0) ? etaDate : undefined,
-        "Bearing, Origin to Destination Waypoint" : bearingOriginToDest,
-        "Bearing, Position to Destination Waypoint" : bearingToDest,
-        "Origin Waypoint Number" : undefined,
-        "Destination Waypoint Number" : parseInt(wpid),
-        "Destination Latitude" : destPos?.position?.latitude,
-        "Destination Longitude" : destPos?.position?.longitude,
-        "Waypoint Closing Velocity" : WCV,
-      }]
-    },
-    tests: [{
-      input: [ 12, 1.23, 3.1, {position: { longitude: -75.487264, latitude: 32.0631296 }} , 4.0, "Rhumbline", null, 1, {pointIndex: 5} ],
-      expected: [{
-        "__preprocess__": (testResult) => {
-          //these change every time
-          delete testResult.fields["ETA Date"]
-          delete testResult.fields["ETA Time"]
+        keys: [
+          'navigation.course.calcValues.distance',
+          'navigation.course.calcValues.bearingTrue',
+          'navigation.course.calcValues.bearingTrackTrue',
+          'navigation.course.calcValues.velocityMadeGood',
+          'navigation.course.calcValues.calcMethod',
+          'notifications.navigation.arrivalCircleEntered',
+          'notifications.navigation.perpendicularPassed',
+        ],
+        interval: 1000,
+        sourceType: 'timer',
+        callback: async (app, distToDest, bearingToDest, bearingOriginToDest, WCV, calcMethod, ace, pp) => {
+          var dateObj = new Date();
+          var secondsToGo = Math.trunc(distToDest / WCV);
+          var etaDate = Math.trunc((dateObj.getTime() / 1000 + secondsToGo) / 86400);
+          var etaTime = (dateObj.getUTCHours() * (60 * 60) +
+                         dateObj.getUTCMinutes() * 60 +
+                         dateObj.getUTCSeconds() +
+                         secondsToGo) % 86400;
+
+          var course = await app.courseApi.getCourse()
+          if (!course)
+              return null
+
+          let waypointId = 1;
+          if (course.activeRoute && typeof course.activeRoute?.pointIndex === 'number')
+            waypointId = course.activeRoute.pointIndex + 1
+
+          sid129284 = sid129284 == 252 ? 0 : sid129284 + 1
+
+          return [{
+            pgn: 129284,
+            "SID" : sid129284,
+            "Distance to Waypoint" :  distToDest,
+            "Course/Bearing reference" : 0,
+            "Perpendicular Crossed" : pp != null,
+            "Arrival Circle Entered" : ace != null,
+            "Calculation Type" : calcMethod == "GreatCircle" ? 0 : 1,
+            "Calculation Type" : calcMethod == "GreatCircle" ? 0 : 1,
+            "ETA Time" : (WCV > 0) ? etaTime : undefined,
+            "ETA Date": (WCV > 0) ? etaDate : undefined,
+            "Bearing, Origin to Destination Waypoint" : bearingOriginToDest,
+            "Bearing, Position to Destination Waypoint" : bearingToDest,
+            "Origin Waypoint Number" : undefined,
+            "Destination Waypoint Number" : waypointId,
+            "Destination Latitude" : course?.nextPoint?.position.latitude,
+            "Destination Longitude" : course?.nextPoint?.position.longitude,
+            "Waypoint Closing Velocity" : WCV,
+          }]
         },
-        "prio": 2,
-        "pgn": 129284,
-        "dst": 255,
-        "fields": {
-          "SID": 136,
-          "Distance to Waypoint": 12,
-          "Course/Bearing reference": "True",
-          "Perpendicular Crossed": "Yes",
-          "Arrival Circle Entered": "No",
-          "Calculation Type": "Rhumbline",
-          "Bearing, Origin to Destination Waypoint": 3.1,
-          "Bearing, Position to Destination Waypoint": 1.23,
-          "Destination Waypoint Number": 6,
-          "Destination Latitude": 32.0631296,
-          "Destination Longitude": -75.487264,
-          "Waypoint Closing Velocity": 4
-        }
+        tests: [{
+          input: [ mockApp, 12, 1.23, 3.1, 4.0, "Rhumbline", null, 1, {pointIndex: 5} ],
+          expected: [{
+            "__preprocess__": (testResult) => {
+              //these change every time
+              delete testResult.fields["ETA Date"]
+              delete testResult.fields["ETA Time"]
+              delete testResult.fields["SID"]
+            },
+            "prio": 2,
+            "pgn": 129284,
+            "dst": 255,
+            "fields": {
+              "Distance to Waypoint": 12,
+              "Course/Bearing reference": "True",
+              "Perpendicular Crossed": "Yes",
+              "Arrival Circle Entered": "No",
+              "Calculation Type": "Rhumbline",
+              "Bearing, Origin to Destination Waypoint": 3.1,
+              "Bearing, Position to Destination Waypoint": 1.23,
+              "Destination Waypoint Number": 1,
+              "Destination Latitude": 38.9749677,
+              "Destination Longitude": -76.4818398,
+              "Waypoint Closing Velocity": 4
+            }
+          }]
+        }]
       }]
-    }]
+    }
   },
   {
     title: 'Route/WP Information (129285)',


### PR DESCRIPTION
A few tweaks / improvements to 129284 based on a bunch of recent experience using it to drive the autopilot and navigate routes in a busy Raymarine EV-1/ACU-400/Axiom system:
- move 129284 to be a timer @ 1s to avoid nmea2000 spam in busy networks. consistent with raymarine axiom / lighthouse 4 behavior.
- improve the calculation of fields in 129284 to be more consistent with commerical chartplotters
- add sid calculation for 129284