### PR TITLE
fix: cast getSelfPath result to number in depth offset calculation

### DIFF
--- a/src/conversions/depth.ts
+++ b/src/conversions/depth.ts
@@ -10,7 +10,7 @@ module.exports = (app:ServerAPI, plugin:Plugin) => {
     callback: (belowTransducer:number): PGN_128267[]|undefined => {
       var surfaceToTransducer = app.getSelfPath('environment.depth.surfaceToTransducer.value')
       var transducerToKeel = app.getSelfPath('environment.depth.transducerToKeel.value')
-      var offset = _.isUndefined(surfaceToTransducer) ? (_.isUndefined(transducerToKeel) ? 0 : transducerToKeel) : surfaceToTransducer
+      var offset: number = _.isUndefined(surfaceToTransducer) ? (_.isUndefined(transducerToKeel) ? 0 : (transducerToKeel as number)) : (surfaceToTransducer as number)
       try {
         return [
           new PGN_128267({


### PR DESCRIPTION
`app.getSelfPath()` has return type `{} | null`, but the `offset` field
of `PGN_128267` expects `number | undefined`. This causes a TypeScript
compile error:

    src/conversions/depth.ts(19,13): error TS2322:
    Type '{} | null' is not assignable to type 'number | undefined'.

Fix by explicitly casting the result of `getSelfPath` to `number` at the
point of use, matching the existing runtime assumption that these paths
return numeric values when defined.

Noticed via the canboat CI which builds this repo against the latest
canboat.json: https://github.com/canboat/canboat/pull/598