### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION

Without a .gitattributes file, git's behaviour on line endings depends on each contributor's local core.autocrlf setting. On Windows this defaults to converting line endings to CRLF on checkout, which causes noisy diffs and can break shell scripts or other tooling.

Adding * text=auto eol=lf tells git to always normalise text files to LF, regardless of the contributor's OS or local git config.